### PR TITLE
Added environment.yml to create ONEFlux environment.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: oneflux_env
+channels:
+  - conda-forge
+dependencies:
+  - python=2.7
+  - numpy>=1.11.0,<1.16.0
+  - scipy>=0.17.0
+  - matplotlib>=1.5.1
+  - statsmodels>=0.8.0


### PR DESCRIPTION
Original install method with requirements.txt messes with the default Python install and ONEFlux does not run if the default is Python 3+.  Added an environment.yml file so that a conda environment can be created in which ONEFlux will run.