### PR TITLE
energy_proc quality flags bugfixes:

### DIFF
--- a/oneflux_steps/energy_proc/src/dataset.c
+++ b/oneflux_steps/energy_proc/src/dataset.c
@@ -1425,13 +1425,13 @@ static int get_meteo(DATASET *const dataset) {
 	for ( token = string_tokenizer(buffer, dataset_delimiter, &p), i = 0; token; token = string_tokenizer(NULL, dataset_delimiter, &p), ++i ) {
 		if ( ! string_compare_i(token, "TA_m") ) {
 			TA = i;
-		} else if ( ! string_compare_i(token, "SWIN_m") ) {
+		} else if ( ! string_compare_i(token, "SW_IN_m") ) {
 			SWIN = i;
 		} else if ( ! string_compare_i(token, "VPD_m") ) {
 			VPD = i;
 		} else if ( ! string_compare_i(token, "TA_mqc") ) {
 			TA_QC = i;
-		} else if ( ! string_compare_i(token, "SWIN_mqc") ) {
+		} else if ( ! string_compare_i(token, "SW_IN_mqc") ) {
 			SWIN_QC = i;
 		} else if ( ! string_compare_i(token, "VPD_mqc") ) {
 			VPD_QC = i;
@@ -1514,7 +1514,12 @@ static int get_meteo(DATASET *const dataset) {
 		}
 		while ( fgets(buffer, BUFFER_SIZE, f) ) {
 			for ( token = string_tokenizer(buffer, dataset_delimiter, &p), i = 0; token; token = string_tokenizer(NULL, dataset_delimiter, &p), i++ ) {
-				if ( !i ) {
+				if ( ! i ) {
+					// skip TIMESTAMP_START
+					continue;
+				}
+				// get TIMESTAMP_END
+				if ( 1 == i ) {
 					t = get_timestamp(token);
 					if ( ! t ) {
 						fclose(f);
@@ -1540,7 +1545,7 @@ static int get_meteo(DATASET *const dataset) {
 					current_row = get_row_by_timestamp(t, (HOURLY_TIMERES==dataset->details->timeres));
 					free(t);
 					if ( element != current_row ) {
-						printf("bad timestamp: %s", token);
+						printf("bad timestamp: %s\n", token);
 						fclose(f);
 						return 0;
 					}							

--- a/oneflux_steps/energy_proc/src/ecbcf.c
+++ b/oneflux_steps/energy_proc/src/ecbcf.c
@@ -450,15 +450,23 @@ int ecbcf_hh(DATASET *const dataset, const int current_row, PREC *const ECBcfs, 
 				/* no method */
 				dataset->rows[current_row].ecbcf_method = INVALID_VALUE-1;
 				dataset->rows[current_row].ecbcf_samples_count = INVALID_VALUE;
-				dataset->gf_rows[LE_INDEX][current_row].quality = INVALID_VALUE;
-				dataset->gf_rows[H_INDEX][current_row].quality = INVALID_VALUE;
+
+				// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+				// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+				// FLUXNET2015 release
+				//dataset->gf_rows[LE_INDEX][current_row].quality = INVALID_VALUE;
+				//dataset->gf_rows[H_INDEX][current_row].quality = INVALID_VALUE;
 			}
 		} else {
 			/* no method */
 			dataset->rows[current_row].ecbcf_method = INVALID_VALUE-1;
 			dataset->rows[current_row].ecbcf_samples_count = INVALID_VALUE;
-			dataset->gf_rows[LE_INDEX][current_row].quality = INVALID_VALUE;
-			dataset->gf_rows[H_INDEX][current_row].quality = INVALID_VALUE;
+
+			// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+			// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+			// FLUXNET2015 release
+			//dataset->gf_rows[LE_INDEX][current_row].quality = INVALID_VALUE;
+			//dataset->gf_rows[H_INDEX][current_row].quality = INVALID_VALUE;
 		}
 	} else if ( SECOND == dataset->rows[current_row].ecbcf_method ) {
 		window = (windows_size_alt / 2) * rows_per_day;
@@ -887,15 +895,23 @@ int ecbcf_dd(DATASET *const dataset, const int current_row, PREC *const ECBcfs, 
 				/* no method */
 				dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 				dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+				// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+				// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+				// FLUXNET2015 release
+				//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+				//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 			}
 		} else {
 			/* no method */
 			dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 			dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+			// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+			// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+			// FLUXNET2015 release
+			//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+			//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 		}
 	} else if ( SECOND == dataset->rows_aggr[current_row].ecbcf_method ) {
 		window = windows_size_alt / 2;
@@ -1197,15 +1213,23 @@ int ecbcf_ww(DATASET *const dataset, const int current_row, PREC *const ECBcfs, 
 				/* no method */
 				dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 				dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+				// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+				// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+				// FLUXNET2015 release
+				//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+				//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 			}
 		} else {
 			/* no method */
 			dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 			dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+			// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+			// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+			// FLUXNET2015 release
+			//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+			//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 		}
 	} else if ( SECOND == dataset->rows_aggr[current_row].ecbcf_method ) {
 		window = window_size / 2;
@@ -1396,15 +1420,23 @@ int ecbcf_mm(DATASET *const dataset, const int current_row, PREC *const ECBcfs, 
 				/* no method */
 				dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 				dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+				// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+				// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+				// FLUXNET2015 release
+				//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+				//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 			}
 		} else {
 			/* no method */
 			dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 			dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+			// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+			// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+			// FLUXNET2015 release
+			//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+			//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 		}
 	} else if ( SECOND == dataset->rows_aggr[current_row].ecbcf_method ) {
 		window = window_size / 2;
@@ -1520,15 +1552,23 @@ int ecbcf_yy(DATASET *const dataset, const int current_row, PREC *const ECBcfs) 
 				/* no method */
 				dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 				dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-				dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+				// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+				// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+				// FLUXNET2015 release
+				//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+				//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 			}
 		} else {
 			/* no method */
 			dataset->rows_aggr[current_row].ecbcf_method = INVALID_VALUE-1;
 			dataset->rows_aggr[current_row].ecbcf_samples_count = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
-			dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
+
+			// commented out on July 25, 2019. It was a bug, changing the value of the QC to -9999 when it was 
+			// not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in 
+			// FLUXNET2015 release
+			//dataset->rows_aggr[current_row].quality[LE_INDEX] = INVALID_VALUE;
+			//dataset->rows_aggr[current_row].quality[H_INDEX] = INVALID_VALUE;
 		}
 	} else if ( SECOND == dataset->rows_aggr[current_row].ecbcf_method ) {
 		/* how many dataset we have ? */


### PR DESCRIPTION
- fixed bug on quality flags for gapfilled LE and H. Correctly calculate the QC value in case of missing data
- renamed vars from SW_IN_M, SW_IN_mqc to SW_IN_m, SW_IN_mqc
- fixed: changing the value of the QC to -9999 when it was not possible to calculate the energy balance and create the LE_Corr. It is also a "known issue" in FLUXNET2015 release
- cosmetic fixes