### PR TITLE
Remove sundown reference partitioning method results

### DIFF
--- a/oneflux/pipeline/common.py
+++ b/oneflux/pipeline/common.py
@@ -96,10 +96,10 @@ NEE_PERC_NEE = os.path.join(NEEDIR, NEE_PERC_NEE_F)
 #NEE_MEF_MATRIX = os.path.join(NEEDIR, '{s}_mef_matrix_{r}_{t}_{fy}_{ly}.csv') # HH, DD, WW, MM, YY __ VUT, CUT
 #ENERGY_INFO = None # No metadata
 UNC_INFO_F = 'info_{s}_{m}_{v}_{r}.txt'
-UNC_INFO = os.path.join(UNCDIR, UNC_INFO_F) # DT, NT, SR __ GPP, RECO __ HH, DD, WW, MM, YY
+UNC_INFO = os.path.join(UNCDIR, UNC_INFO_F) # DT, NT __ GPP, RECO __ HH, DD, WW, MM, YY
 UNC_INFO_ALT_F = '{s}_{m}_{v}_{r}_info.txt'
-UNC_INFO_ALT = os.path.join(UNCDIR, UNC_INFO_ALT_F) # DT, NT, SR __ GPP, RECO __ HH, DD, WW, MM, YY
-#UNC_MEF_MATRIX = os.path.join(UNCDIR, '{s}_{m}_{v}_mef_matrix_{r}_{t}_{fy}_{ly}.csv') # DT, NT, SR __ GPP, RECO __ HH, DD, WW, MM, YY __ VUT, CUT
+UNC_INFO_ALT = os.path.join(UNCDIR, UNC_INFO_ALT_F) # DT, NT __ GPP, RECO __ HH, DD, WW, MM, YY
+#UNC_MEF_MATRIX = os.path.join(UNCDIR, '{s}_{m}_{v}_mef_matrix_{r}_{t}_{fy}_{ly}.csv') # DT, NT __ GPP, RECO __ HH, DD, WW, MM, YY __ VUT, CUT
 
 FULLSET_STR = 'FULLSET'
 SUBSET_STR = 'SUBSET'

--- a/oneflux/pipeline/variables_codes.py
+++ b/oneflux/pipeline/variables_codes.py
@@ -289,13 +289,7 @@ VARIABLE_LIST_FULL = [
 'GPP_DT_CUT_MEAN',
 'GPP_DT_CUT_SE',
 ] + \
-['GPP_DT_CUT_{n}'.format(n=i) for i in ['05', '16', '25', '50', '75', '84', '95']] + \
-[
-
-### PARTITIONING SUNDOWN
-'RECO_SR',
-'RECO_SR_N'
-]
+['GPP_DT_CUT_{n}'.format(n=i) for i in ['05', '16', '25', '50', '75', '84', '95']]
 
 for i, e in enumerate(VARIABLE_LIST_FULL):
     if VARIABLE_LIST_FULL.count(e) != 1:
@@ -393,11 +387,7 @@ VARIABLE_LIST_SUB = [
 [
 'GPP_DT_VUT_REF',
 ] + \
-['GPP_DT_VUT_{n}'.format(n=i) for i in ['25', '50', '75']] + \
-[
-'RECO_SR',
-'RECO_SR_N',
-]
+['GPP_DT_VUT_{n}'.format(n=i) for i in ['25', '50', '75']]
 
 for i, e in enumerate(VARIABLE_LIST_SUB):
     if VARIABLE_LIST_SUB.count(e) != 1:
@@ -667,13 +657,7 @@ VARIABLE_LIST_FULL_MAP = [
 ['GPP_DT_CUT_MEAN', ['DT_GPP_mean_c', ]],
 ['GPP_DT_CUT_SE', ['DT_GPP_SE_c', ]],
 ] + \
-[['GPP_DT_CUT_{n}'.format(n=i), ['DT_GPP_{n}_c'.format(n=i), ]] for i in ['05', '16', '25', '50', '75', '84', '95']] + \
-[
-
-### PARTITIONING SUNDOWN
-['RECO_SR', ['SR_RECO', ]],
-['RECO_SR_N', ['SR_RECO_n', 'SR_RECO_N']],
-]
+[['GPP_DT_CUT_{n}'.format(n=i), ['DT_GPP_{n}_c'.format(n=i), ]] for i in ['05', '16', '25', '50', '75', '84', '95']]
 
 FULL_DIRECT_D = {i[0]:i[1] for i in VARIABLE_LIST_FULL_MAP}
 
@@ -789,7 +773,6 @@ VARIABLE_LIST_COULD_BE_PRESENT = [
     'H_CORR_25', 'H_CORR_75', 'H_RANDUNC_METHOD', 'H_RANDUNC_N', 'H_CORR_JOINTUNC',
     'NEE_CUT_REF', 'NEE_CUT_REF_QC', 'NEE_CUT_REF_RANDUNC',
     'RECO_NT_CUT_REF', 'GPP_NT_CUT_REF', 'RECO_DT_CUT_REF', 'GPP_DT_CUT_REF',
-    'RECO_SR', 'RECO_SR_N',
     ] + \
    ['TS_F_MDS_{n}'.format(n=i) for i in range(1, 20)] + \
    ['TS_F_MDS_{n}_QC'.format(n=i) for i in range(1, 20)] + \


### PR DESCRIPTION
The sundown reference partitioning method was part of FLUXNET2015 for the sites in which the method could be applied. The limited number of sites meeting the requirements for the method to be applied made it difficult to to be used for cross-site comparisons, and it has not been included in ONEFlux results from regional network-published FLUXNET data products. With that, it is being removed from the partitioning results expected within ONEFlux runs.