### PR TITLE
fixed "ISO C99 and later do not support implicit int" 

### DIFF
--- a/oneflux_steps/energy_proc/src/dataset.c
+++ b/oneflux_steps/energy_proc/src/dataset.c
@@ -1357,7 +1357,7 @@ int debug_save_aggr_by_year(const DATASET *const dataset, const PREC *const ECBc
 
 
 /* */
-static check_le_h(DATASET *const dataset) {
+static int check_le_h(DATASET *const dataset) {
 	int i;
 	int flag = 0;
 


### PR DESCRIPTION
error on C99 and later compilers

(checked against Apple clang version 15.0.0 (clang-1500.3.9.4))