### PR TITLE
nee_proc: _c files are now computed even if _y computation fails

### DIFF
--- a/oneflux_steps/nee_proc/src/dataset.c
+++ b/oneflux_steps/nee_proc/src/dataset.c
@@ -1481,7 +1481,7 @@ ROW_NIGHT *compute_nights(DATASET *const dataset,
 		for ( y = 0; y < NIGHT_RAND_VALUES; y++ ) {
 			/* do not compute _y if it was skipped */
 			if ( ! nee_matrix_y &&
-					((NEE_REF_Y == y) || (NEE_UST50_Y == y) || (NEE_REF_Y_RAND == y) || (NEE_UST50_Y_RAND)) ) {
+					((NEE_REF_Y == y) || (NEE_UST50_Y == y) || (NEE_REF_Y_RAND == y) || (NEE_UST50_Y_RAND == y)) ) {
 				continue;
 			}
 			/* do not compute _c if years count is less than 3 */
@@ -1846,13 +1846,11 @@ static int compute_night_rand(const DATASET *const dataset, ROW_NIGHT *const row
 		/* loop on each var to compute */
 		for ( y = NIGHT_QC_VALUES; y < NIGHT_RAND_VALUES; y++ ) {
 			/* do not compute _y if ... */
-			if (	skip_y &&
-					((NEE_REF_Y == y) || (NEE_UST50_Y == y) || (NEE_REF_Y_RAND == y) || (NEE_UST50_Y_RAND == y)) ) {
+			if (	skip_y && ((NEE_REF_Y_RAND == y) || (NEE_UST50_Y_RAND == y)) ) {
 				continue;
 			}
 			/* do not compute _c if years count is less than 3 */
-			if ( (dataset->years_count < 3) &&
-					((NEE_REF_C == y) || (NEE_UST50_C == y) || (NEE_REF_C_RAND == y) || (NEE_UST50_C_RAND == y)) ) {
+			if ( (dataset->years_count < 3) && ((NEE_REF_C_RAND == y) || (NEE_UST50_C_RAND == y)) ) {
 				continue;
 			}
 			rows_night[index].night[y] = 0.0;
@@ -4368,24 +4366,22 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		if ( datasets[dataset].years_count >= 3 ) {
 			/* get uts_c */
-			if ( datasets[dataset].years_count >= 3 ) {
-				if ( !get_uts_c(datasets[dataset].details->site, datasets[dataset].years, datasets[dataset].years_count, uts, &uts_count) ) {
-					if ( compute_nee_flags ) {
-						if ( datasets[dataset].years_count >= 3 ) {
-							free(nee_flags_c);
-						}
-						free(nee_flags_y);
+			if ( !get_uts_c(datasets[dataset].details->site, datasets[dataset].years, datasets[dataset].years_count, uts, &uts_count) ) {
+				if ( compute_nee_flags ) {
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_flags_c);
 					}
-					free(unc_rows_temp);
-					free(unc_rows_aggr);
-					free(unc_rows);
-					free(nee_matrix_y);
-					free(percentiles_y);
-					free(nee_matrix_c);
-					free(uts);
-					free(rows_copy);
-					continue;
+					free(nee_flags_y);
 				}
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(nee_matrix_y);
+				free(percentiles_y);
+				free(nee_matrix_c);
+				free(uts);
+				free(rows_copy);
+				continue;
 			}
 
 			/* get percentiles */

--- a/oneflux_steps/nee_proc/src/dataset.c
+++ b/oneflux_steps/nee_proc/src/dataset.c
@@ -1472,9 +1472,18 @@ ROW_NIGHT *compute_nights(DATASET *const dataset,
 	index = 0;
 
 	/* */
+	night_d = 0;
+	day_d = 0;
+	
+	/* */
 	for ( row = 0; row < dataset->rows_count; row += rows_per_day ) {
 		/* loop on each var to compute */
 		for ( y = 0; y < NIGHT_RAND_VALUES; y++ ) {
+			/* do not compute _y if it was skipped */
+			if ( ! nee_matrix_y &&
+					((NEE_REF_Y == y) || (NEE_UST50_Y == y) || (NEE_REF_Y_RAND == y) || (NEE_UST50_Y_RAND)) ) {
+				continue;
+			}
 			/* do not compute _c if years count is less than 3 */
 			if ( (dataset->years_count < 3) &&
 					((NEE_REF_C == y) || (NEE_UST50_C == y) || (NEE_REF_C_RAND == y) || (NEE_UST50_C_RAND == y)) ) {
@@ -1612,88 +1621,90 @@ ROW_NIGHT *compute_nights(DATASET *const dataset,
 		}
 
 		/* ... per y */
-		for ( y = 0; y < PERCENTILES_COUNT_2; y++ ) {
-			night_d = 0;
-			day_d = 0;
-			nights[0] = 0.0;
-			days[0] = 0.0;
-			nights_qc = 0.0;
-			days_qc = 0.0;
+		if ( nee_matrix_y ) {
+			for ( y = 0; y < PERCENTILES_COUNT_2; y++ ) {
+				night_d = 0;
+				day_d = 0;
+				nights[0] = 0.0;
+				days[0] = 0.0;
+				nights_qc = 0.0;
+				days_qc = 0.0;
 
-			/* */
-			for ( i = 0; i < rows_per_day; i++ ) {
-				value = nee_matrix_y[row+i].nee[y];
-				qc = nee_matrix_y[row+i].qc[y];
+				/* */
+				for ( i = 0; i < rows_per_day; i++ ) {
+					value = nee_matrix_y[row+i].nee[y];
+					qc = nee_matrix_y[row+i].qc[y];
 
-				/* night ? */
-				if ( ARE_FLOATS_EQUAL(dataset->rows[row+i].value[RPOT_VALUE], 0.0) ) {
-					if ( !IS_INVALID_VALUE(value) ) {
-						nights[0] += value;
-						nights_qc += qc;
-						++night_d;
-					}				
-				} else {
-					if ( !IS_INVALID_VALUE(value) ) {
-						days[0] += value;
-						days_qc += qc;
-						++day_d;
+					/* night ? */
+					if ( ARE_FLOATS_EQUAL(dataset->rows[row+i].value[RPOT_VALUE], 0.0) ) {
+						if ( !IS_INVALID_VALUE(value) ) {
+							nights[0] += value;
+							nights_qc += qc;
+							++night_d;
+						}				
+					} else {
+						if ( !IS_INVALID_VALUE(value) ) {
+							days[0] += value;
+							days_qc += qc;
+							++day_d;
+						}
 					}
 				}
+				if ( night_d ) {
+					rows_night[index].night_columns_y[y] = nights[0] / night_d;
+					rows_night[index].night_qc_columns_y[y] = nights_qc / night_d;
+				} else {
+					rows_night[index].night_columns_y[y] = INVALID_VALUE;
+					rows_night[index].night_qc_columns_y[y] = INVALID_VALUE;
+				}
+				if ( day_d ) {
+					rows_night[index].day_columns_y[y] = days[0] / day_d;
+					rows_night[index].day_qc_columns_y[y] = days_qc / day_d;
+				} else {
+					rows_night[index].day_columns_y[y] = INVALID_VALUE;
+					rows_night[index].day_qc_columns_y[y] = INVALID_VALUE;
+				}
 			}
-			if ( night_d ) {
-				rows_night[index].night_columns_y[y] = nights[0] / night_d;
-				rows_night[index].night_qc_columns_y[y] = nights_qc / night_d;
-			} else {
-				rows_night[index].night_columns_y[y] = INVALID_VALUE;
-				rows_night[index].night_qc_columns_y[y] = INVALID_VALUE;
-			}
-			if ( day_d ) {
-				rows_night[index].day_columns_y[y] = days[0] / day_d;
-				rows_night[index].day_qc_columns_y[y] = days_qc / day_d;
-			} else {
-				rows_night[index].day_columns_y[y] = INVALID_VALUE;
-				rows_night[index].day_qc_columns_y[y] = INVALID_VALUE;
-			}
-		}
 
-		/* computing percentiles for y, night */
-		for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
-			if ( night_d ) {
-				rows_night[index].night[ii] = get_percentile_and_qc(rows_night[index].night_columns_y, rows_night[index].night_qc_columns_y
-												, PERCENTILES_COUNT_2-1, percentiles_test_1[ii-NEE_05_Y]
-												/* +7 for indexing QC */
-												, &rows_night[index].night[ii+7], &error);
-			} else {
-				rows_night[index].night[ii] = INVALID_VALUE;
-				rows_night[index].night[ii+7] = INVALID_VALUE;
+			/* computing percentiles for y, night */
+			for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
+				if ( night_d ) {
+					rows_night[index].night[ii] = get_percentile_and_qc(rows_night[index].night_columns_y, rows_night[index].night_qc_columns_y
+													, PERCENTILES_COUNT_2-1, percentiles_test_1[ii-NEE_05_Y]
+													/* +7 for indexing QC */
+													, &rows_night[index].night[ii+7], &error);
+				} else {
+					rows_night[index].night[ii] = INVALID_VALUE;
+					rows_night[index].night[ii+7] = INVALID_VALUE;
+				}
+				if ( error ) {
+					printf("unable to get night %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					free(days);
+					free(nights);
+					free(rows_night);
+					return NULL;
+				}
 			}
-			if ( error ) {
-				printf("unable to get night %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				free(days);
-				free(nights);
-				free(rows_night);
-				return NULL;
-			}
-		}
 
-		/* computing percentiles for y, day */
-		for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
-			if ( day_d ) {
-				rows_night[index].day[ii] = get_percentile_and_qc(rows_night[index].day_columns_y, rows_night[index].day_qc_columns_y
-												, PERCENTILES_COUNT_2-1, percentiles_test_1[ii-NEE_05_Y]
-												/* +7 for indexing QC */
-												, &rows_night[index].day[ii+7], &error);
-			} else {
-				rows_night[index].day[ii] = INVALID_VALUE;
-				rows_night[index].day[ii+7] = INVALID_VALUE;
-			}
-			if ( error ) {
-				printf("unable to get day %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				free(days);
-				free(nights);
-				free(rows_night);
-				return NULL;
-			}
+			/* computing percentiles for y, day */
+			for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
+				if ( day_d ) {
+					rows_night[index].day[ii] = get_percentile_and_qc(rows_night[index].day_columns_y, rows_night[index].day_qc_columns_y
+													, PERCENTILES_COUNT_2-1, percentiles_test_1[ii-NEE_05_Y]
+													/* +7 for indexing QC */
+													, &rows_night[index].day[ii+7], &error);
+				} else {
+					rows_night[index].day[ii] = INVALID_VALUE;
+					rows_night[index].day[ii+7] = INVALID_VALUE;
+				}
+				if ( error ) {
+					printf("unable to get day %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					free(days);
+					free(nights);
+					free(rows_night);
+					return NULL;
+				}
+			}		
 		}
 		
 		/* ... per c */
@@ -1796,7 +1807,7 @@ ROW_NIGHT *compute_nights(DATASET *const dataset,
 }
 
 /* */
-static int compute_night_rand(const DATASET *const dataset, ROW_NIGHT *const rows_night, const RAND_UNC_ROW *const unc_rows) {
+static int compute_night_rand(const DATASET *const dataset, ROW_NIGHT *const rows_night, const RAND_UNC_ROW *const unc_rows, const int skip_y) {
 	int i;
 	int y;
 	int row;
@@ -1834,6 +1845,11 @@ static int compute_night_rand(const DATASET *const dataset, ROW_NIGHT *const row
 	for ( row = 0; row < dataset->rows_count; row += rows_per_day ) {
 		/* loop on each var to compute */
 		for ( y = NIGHT_QC_VALUES; y < NIGHT_RAND_VALUES; y++ ) {
+			/* do not compute _y if ... */
+			if (	skip_y &&
+					((NEE_REF_Y == y) || (NEE_UST50_Y == y) || (NEE_REF_Y_RAND == y) || (NEE_UST50_Y_RAND == y)) ) {
+				continue;
+			}
 			/* do not compute _c if years count is less than 3 */
 			if ( (dataset->years_count < 3) &&
 					((NEE_REF_C == y) || (NEE_UST50_C == y) || (NEE_REF_C_RAND == y) || (NEE_UST50_C_RAND == y)) ) {
@@ -1931,7 +1947,7 @@ static int compute_night_rand(const DATASET *const dataset, ROW_NIGHT *const row
 }
 
 /* */
-static void rand_unc_dd(RAND_UNC_ROW *const unc_rows, RAND_UNC_ROW *const unc_rows_aggr, const int rows_count, const int years_count, const int hourly) {
+static void rand_unc_dd(RAND_UNC_ROW *const unc_rows, RAND_UNC_ROW *const unc_rows_aggr, const int rows_count, const int years_count, const int hourly, const int skip_y) {
 	int i;
 	int j;
 	int day;
@@ -1944,10 +1960,12 @@ static void rand_unc_dd(RAND_UNC_ROW *const unc_rows, RAND_UNC_ROW *const unc_ro
 	/* loop on each row */
 	day = 0;
 	for ( i = 0; i < rows_count; i += rows_per_day ) {
-		unc_rows_aggr[day].rand[NEE_REF_Y_UNC] = 0.0;
-		unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] = 0.0;
-		unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC] = 0;
-		unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC] = 0;
+		if ( ! skip_y ) {
+			unc_rows_aggr[day].rand[NEE_REF_Y_UNC] = 0.0;
+			unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] = 0.0;
+			unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC] = 0;
+			unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC] = 0;
+		}
 		if ( years_count > 2 ) {
 			unc_rows_aggr[day].rand[NEE_REF_C_UNC] = 0.0;
 			unc_rows_aggr[day].rand[NEE_UST50_C_UNC] = 0.0;
@@ -1955,13 +1973,15 @@ static void rand_unc_dd(RAND_UNC_ROW *const unc_rows, RAND_UNC_ROW *const unc_ro
 			unc_rows_aggr[day].samples_count[NEE_UST50_C_UNC] = 0;
 		}
 		for ( j = 0; j < rows_per_day; j++ ) {
-			if ( !IS_INVALID_VALUE(unc_rows[i+j].rand[NEE_REF_Y_UNC]) ) {
-				unc_rows_aggr[day].rand[NEE_REF_Y_UNC] += (unc_rows[i+j].rand[NEE_REF_Y_UNC] * unc_rows[i+j].rand[NEE_REF_Y_UNC]);
-				++unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC];
-			}
-			if ( !IS_INVALID_VALUE(unc_rows[i+j].rand[NEE_UST50_Y_UNC]) ) {
-				unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] += (unc_rows[i+j].rand[NEE_UST50_Y_UNC] * unc_rows[i+j].rand[NEE_UST50_Y_UNC]);
-				++unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC];
+			if ( ! skip_y ) {
+				if ( !IS_INVALID_VALUE(unc_rows[i+j].rand[NEE_REF_Y_UNC]) ) {
+					unc_rows_aggr[day].rand[NEE_REF_Y_UNC] += (unc_rows[i+j].rand[NEE_REF_Y_UNC] * unc_rows[i+j].rand[NEE_REF_Y_UNC]);
+					++unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC];
+				}
+				if ( !IS_INVALID_VALUE(unc_rows[i+j].rand[NEE_UST50_Y_UNC]) ) {
+					unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] += (unc_rows[i+j].rand[NEE_UST50_Y_UNC] * unc_rows[i+j].rand[NEE_UST50_Y_UNC]);
+					++unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC];
+				}
 			}
 			if ( years_count > 2 ) {
 				if ( !IS_INVALID_VALUE(unc_rows[i+j].rand[NEE_REF_C_UNC]) ) {
@@ -1974,20 +1994,21 @@ static void rand_unc_dd(RAND_UNC_ROW *const unc_rows, RAND_UNC_ROW *const unc_ro
 				}
 			}
 		}
-		if ( unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC] ) {
-			unc_rows_aggr[day].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_aggr[day].rand[NEE_REF_Y_UNC]) / unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC];
-			unc_rows_aggr[day].rand[NEE_REF_Y_UNC] *= CO2TOC;
-		} else {
-			unc_rows_aggr[day].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
-		}
+		if ( ! skip_y ) {
+			if ( unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC] ) {
+				unc_rows_aggr[day].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_aggr[day].rand[NEE_REF_Y_UNC]) / unc_rows_aggr[day].samples_count[NEE_REF_Y_UNC];
+				unc_rows_aggr[day].rand[NEE_REF_Y_UNC] *= CO2TOC;
+			} else {
+				unc_rows_aggr[day].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
+			}
 
-		if ( unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC] ) {
-			unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_aggr[day].rand[NEE_UST50_Y_UNC]) / unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC];
-			unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] *= CO2TOC;
-		} else {
-			unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+			if ( unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC] ) {
+				unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_aggr[day].rand[NEE_UST50_Y_UNC]) / unc_rows_aggr[day].samples_count[NEE_UST50_Y_UNC];
+				unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] *= CO2TOC;
+			} else {
+				unc_rows_aggr[day].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+			}
 		}
-
 		if ( years_count > 2 ) {
 			if ( unc_rows_aggr[day].samples_count[NEE_REF_C_UNC] ) {
 				unc_rows_aggr[day].rand[NEE_REF_C_UNC] = SQRT(unc_rows_aggr[day].rand[NEE_REF_C_UNC]) / unc_rows_aggr[day].samples_count[NEE_REF_C_UNC];
@@ -2024,7 +2045,7 @@ static void rand_unc_dd(RAND_UNC_ROW *const unc_rows, RAND_UNC_ROW *const unc_ro
 
 	This is the equation used in the code. The same applied to all the other aggregations.
 */
-static void rand_unc_ww(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const unc_rows_temp, const int rows_count, const int start_year, const int years_count) {
+static void rand_unc_ww(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const unc_rows_temp, const int rows_count, const int start_year, const int years_count, const int skip_y) {
 	int i;
 	int k;
 	int w;
@@ -2044,10 +2065,12 @@ static void rand_unc_ww(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 				days_per_week = (IS_LEAP_YEAR(year) ? 366 : 365) - 51*7;
 			}
 			/* */
-			unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] = 0.0;
-			unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] = 0.0;
-			unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC] = 0;
-			unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC] = 0;
+			if ( ! skip_y ) {
+				unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] = 0.0;
+				unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] = 0.0;
+				unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC] = 0;
+				unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC] = 0;
+			}
 			if ( years_count > 2 ) {
 				unc_rows_temp[week+w].rand[NEE_REF_C_UNC] = 0.0;
 				unc_rows_temp[week+w].rand[NEE_UST50_C_UNC] = 0.0;
@@ -2055,19 +2078,21 @@ static void rand_unc_ww(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 				unc_rows_temp[week+w].samples_count[NEE_UST50_C_UNC] = 0;
 			}
 			for ( i = 0; i < days_per_week; i++ ) {
-				if ( ! IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC]) ) {
-					value = unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC];
-					value *= value;
-					value *= (unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]);
-					unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] += value;
-					unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC];
-				}
-				if ( ! IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC]) ) {
-					value = unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC];
-					value *= value;
-					value *= (unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]);
-					unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] += value;
-					unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC];
+				if ( ! skip_y ) {
+					if ( ! IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC]) ) {
+						value = unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC];
+						value *= value;
+						value *= (unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]);
+						unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] += value;
+						unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC];
+					}
+					if ( ! IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC]) ) {
+						value = unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC];
+						value *= value;
+						value *= (unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]);
+						unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] += value;
+						unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC];
+					}
 				}
 				if ( years_count > 2 ) {
 					if ( ! IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_C_UNC]) ) {
@@ -2086,16 +2111,19 @@ static void rand_unc_ww(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 					}
 				}
 			}
-			if ( unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC] ) {
-				unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_temp[week+w].rand[NEE_REF_Y_UNC]) / unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC];
-			} else {
-				unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
-			}
 
-			if ( unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC] ) {
-				unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC]) / unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC];
-			} else {
-				unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+			if ( ! skip_y ) {
+				if ( unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC] ) {
+					unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_temp[week+w].rand[NEE_REF_Y_UNC]) / unc_rows_temp[week+w].samples_count[NEE_REF_Y_UNC];
+				} else {
+					unc_rows_temp[week+w].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
+				}
+
+				if ( unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC] ) {
+					unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC]) / unc_rows_temp[week+w].samples_count[NEE_UST50_Y_UNC];
+				} else {
+					unc_rows_temp[week+w].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+				}
 			}
 
 			if ( years_count > 2 ) {
@@ -2121,7 +2149,7 @@ static void rand_unc_ww(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 /* 
 	please see rand_unc_ww for infos
 */
-static void rand_unc_mm(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const unc_rows_temp, const int rows_count, const int start_year, const int years_count) {
+static void rand_unc_mm(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const unc_rows_temp, const int rows_count, const int start_year, const int years_count, const int skip_y) {
 	int i;
 	int k;
 	int m;
@@ -2140,12 +2168,13 @@ static void rand_unc_mm(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 			if ( (FEBRUARY == month) && IS_LEAP_YEAR(year) ) {
 				++days_per_month_count;
 			}
-
 			/* */
-			unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] = 0.0;
-			unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] = 0.0;
-			unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC] = 0;
-			unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC] = 0;
+			if ( ! skip_y ) {
+				unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] = 0.0;
+				unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] = 0.0;
+				unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC] = 0;
+				unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC] = 0;
+			}
 			if ( years_count > 2 ) {
 				unc_rows_temp[month+m].rand[NEE_REF_C_UNC] = 0.0;
 				unc_rows_temp[month+m].rand[NEE_UST50_C_UNC] = 0.0;
@@ -2153,19 +2182,21 @@ static void rand_unc_mm(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 				unc_rows_temp[month+m].samples_count[NEE_UST50_C_UNC] = 0;
 			}
 			for ( i = 0; i < days_per_month_count; i++ ) {
-				if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC]) ) {
-					value = unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC];
-					value *= value;
-					value *= (unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]);
-					unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] += value;
-					unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC];
-				}
-				if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC]) ) {
-					value = unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC];
-					value *= value;
-					value *= (unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]);
-					unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] += value;
-					unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC];
+				if ( ! skip_y ) {
+					if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC]) ) {
+						value = unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC];
+						value *= value;
+						value *= (unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]);
+						unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] += value;
+						unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC];
+					}
+					if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC]) ) {
+						value = unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC];
+						value *= value;
+						value *= (unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]);
+						unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] += value;
+						unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC];
+					}
 				}
 				if ( years_count > 2 ) {
 					if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_C_UNC]) ) {
@@ -2184,18 +2215,19 @@ static void rand_unc_mm(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 					}
 				}
 			}
-			if ( unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC] ) {
-				unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_temp[month+m].rand[NEE_REF_Y_UNC]) / unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC];
-			} else {
-				unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
-			}
+			if ( ! skip_y ) {
+				if ( unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC] ) {
+					unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_temp[month+m].rand[NEE_REF_Y_UNC]) / unc_rows_temp[month+m].samples_count[NEE_REF_Y_UNC];
+				} else {
+					unc_rows_temp[month+m].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
+				}
 
-			if ( unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC] ) {
-				unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC]) / unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC];
-			} else {
-				unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+				if ( unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC] ) {
+					unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC]) / unc_rows_temp[month+m].samples_count[NEE_UST50_Y_UNC];
+				} else {
+					unc_rows_temp[month+m].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+				}
 			}
-
 			if ( years_count > 2 ) {
 				if ( unc_rows_temp[month+m].samples_count[NEE_REF_C_UNC] ) {
 					unc_rows_temp[month+m].rand[NEE_REF_C_UNC] = SQRT(unc_rows_temp[month+m].rand[NEE_REF_C_UNC]) / unc_rows_temp[month+m].samples_count[NEE_REF_C_UNC];
@@ -2219,7 +2251,7 @@ static void rand_unc_mm(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 /* 
 	please see rand_unc_ww for infos
 */
-static void rand_unc_yy(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const unc_rows_temp, const int rows_count, const int start_year, const int years_count) {
+static void rand_unc_yy(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const unc_rows_temp, const int rows_count, const int start_year, const int years_count, const int skip_y) {
 	int i;
 	int k;
 	int rows_per_year_count;
@@ -2232,12 +2264,13 @@ static void rand_unc_yy(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 	year = start_year;
 	while ( k < rows_count ) {
 		rows_per_year_count = IS_LEAP_YEAR(year) ? 366: 365;
-
 		/* */
-		unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] = 0.0;
-		unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] = 0.0;
-		unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC] = 0;
-		unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC] = 0;
+		if ( ! skip_y ) {
+			unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] = 0.0;
+			unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] = 0.0;
+			unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC] = 0;
+			unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC] = 0;
+		}
 		if ( years_count > 2 ) {
 			unc_rows_temp[year_index].rand[NEE_REF_C_UNC] = 0.0;
 			unc_rows_temp[year_index].rand[NEE_UST50_C_UNC] = 0.0;
@@ -2245,19 +2278,21 @@ static void rand_unc_yy(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 			unc_rows_temp[year_index].samples_count[NEE_UST50_C_UNC] = 0;
 		}
 		for ( i = 0; i < rows_per_year_count; i++ ) {
-			if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC]) ) {
-				value = unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC];
-				value *= value;
-				value *= (unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]);
-				unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] += value;
-				unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC];
-			}
-			if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC]) ) {
-				value = unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC];
-				value *= value;
-				value *= (unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]);
-				unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] += value;
-				unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC];
+			if ( ! skip_y ) {
+				if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC]) ) {
+					value = unc_rows_aggr[i+k].rand[NEE_REF_Y_UNC];
+					value *= value;
+					value *= (unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC]);
+					unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] += value;
+					unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_REF_Y_UNC];
+				}
+				if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC]) ) {
+					value = unc_rows_aggr[i+k].rand[NEE_UST50_Y_UNC];
+					value *= value;
+					value *= (unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]*unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC]);
+					unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] += value;
+					unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC] += unc_rows_aggr[i+k].samples_count[NEE_UST50_Y_UNC];
+				}
 			}
 			if ( years_count > 2 ) {
 				if ( !IS_INVALID_VALUE(unc_rows_aggr[i+k].rand[NEE_REF_C_UNC]) ) {
@@ -2276,20 +2311,21 @@ static void rand_unc_yy(RAND_UNC_ROW *const unc_rows_aggr, RAND_UNC_ROW *const u
 				}
 			}
 		}
-		if ( unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC] ) {
-			unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_temp[year_index].rand[NEE_REF_Y_UNC]) / unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC];
-			unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] *= rows_per_year_count;
-		} else {
-			unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
-		}
+		if ( ! skip_y ) {
+			if ( unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC] ) {
+				unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] = SQRT(unc_rows_temp[year_index].rand[NEE_REF_Y_UNC]) / unc_rows_temp[year_index].samples_count[NEE_REF_Y_UNC];
+				unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] *= rows_per_year_count;
+			} else {
+				unc_rows_temp[year_index].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
+			}
 
-		if ( unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC] ) {
-			unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC]) / unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC];
-			unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] *= rows_per_year_count;
-		} else {
-			unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+			if ( unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC] ) {
+				unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] = SQRT(unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC]) / unc_rows_temp[year_index].samples_count[NEE_UST50_Y_UNC];
+				unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] *= rows_per_year_count;
+			} else {
+				unc_rows_temp[year_index].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+			}
 		}
-
 		if ( years_count > 2 ) {
 			if ( unc_rows_temp[year_index].samples_count[NEE_REF_C_UNC] ) {
 				unc_rows_temp[year_index].rand[NEE_REF_C_UNC] = SQRT(unc_rows_temp[year_index].rand[NEE_REF_C_UNC]) / unc_rows_temp[year_index].samples_count[NEE_REF_C_UNC];
@@ -2360,16 +2396,20 @@ int save_info(const DATASET *const dataset, const char *const path, const eTimeR
 	if ( dataset->years_count >= 3 ) {
 		/* u* threshold used */
 		fprintf(f, ustar_threshold_c, percentiles_c[PERCENTILES_COUNT_2-1]);
-		for ( i = 0; i < dataset->years_count; i++ ) {
-			fprintf(f, ustar_threshold_y, dataset->years[i].year, percentiles_y[i].value[PERCENTILES_COUNT_2-1]);
+		if ( percentiles_y ) {
+			for ( i = 0; i < dataset->years_count; i++ ) {
+				fprintf(f, ustar_threshold_y, dataset->years[i].year, percentiles_y[i].value[PERCENTILES_COUNT_2-1]);
+			}
 		}
 		/* model efficiency */
 		fputs(info_model_efficiency, f);
 		fprintf(f, model_efficiency_c, percentiles_test_2[ref_c], percentiles_c[ref_c]);
-		for ( i = 0; i < dataset->years_count; i++ ) {
-			fprintf(f, model_efficiency_y, dataset->years[i].year, percentiles_test_2[ref_y], percentiles_y[i].value[ref_y]);
+		if ( percentiles_y ) {
+			for ( i = 0; i < dataset->years_count; i++ ) {
+				fprintf(f, model_efficiency_y, dataset->years[i].year, percentiles_test_2[ref_y], percentiles_y[i].value[ref_y]);
+			}
 		}
-	} else {
+	} else if ( percentiles_y ) {
 		/* u* threshold used */
 		fprintf(f, ustar_threshold_y_one_year, percentiles_y[0].value[PERCENTILES_COUNT_2-1]);
 		/* model efficiency */
@@ -2392,14 +2432,18 @@ int save_info(const DATASET *const dataset, const char *const path, const eTimeR
 	if ( dataset->years_count >= 3 ) {
 		fprintf(f, "NEE_CUT_USTAR50,-9999,-9999,%g\n", percentiles_c[PERCENTILES_COUNT_2-1]);
 	}
-	for ( i = 0; i < dataset->years_count; i++ ) {
-		fprintf(f, "NEE_VUT_USTAR50,%d,-9999,%g\n", dataset->years[i].year, percentiles_y[i].value[PERCENTILES_COUNT_2-1]);
+	if ( percentiles_y ) {
+		for ( i = 0; i < dataset->years_count; i++ ) {
+			fprintf(f, "NEE_VUT_USTAR50,%d,-9999,%g\n", dataset->years[i].year, percentiles_y[i].value[PERCENTILES_COUNT_2-1]);
+		}
 	}
 	if ( dataset->years_count >= 3 ) {
 		fprintf(f, "NEE_CUT_REF,-9999,%g,%g\n", percentiles_test_2[ref_c], percentiles_c[ref_c]);
 	}
-	for ( i = 0; i < dataset->years_count; i++ ) {
-		fprintf(f, "NEE_VUT_REF,%d,%g,%g\n", dataset->years[i].year, percentiles_test_2[ref_y], percentiles_y[i].value[ref_y]);
+	if ( percentiles_y ) {
+		for ( i = 0; i < dataset->years_count; i++ ) {
+			fprintf(f, "NEE_VUT_REF,%d,%g,%g\n", dataset->years[i].year, percentiles_test_2[ref_y], percentiles_y[i].value[ref_y]);
+		}
 	}
 	fclose(f);
 
@@ -2554,40 +2598,42 @@ static void update_ref(const DATASET *const dataset
 	rows_per_day = (HOURLY_TIMERES == dataset->details->timeres) ? 24 : 48;
 
 	/* night & day y */
-	for ( row_daily = 0; row_daily < daily_rows_count; ++row_daily ) {
-		rows_night_daily[row_daily].night[NEE_REF_Y] = rows_night_daily[row_daily].night_columns_y[ref_y];
-		rows_night_daily[row_daily].night_qc[NEE_REF_Y] = rows_night_daily[row_daily].night_qc_columns_y[ref_y];
-		rows_night_daily[row_daily].day[NEE_REF_Y] = rows_night_daily[row_daily].day_columns_y[ref_y];
-		rows_night_daily[row_daily].day_qc[NEE_REF_Y] = rows_night_daily[row_daily].day_qc_columns_y[ref_y];
+	if ( nee_matrix_y ) {
+		for ( row_daily = 0; row_daily < daily_rows_count; ++row_daily ) {
+			rows_night_daily[row_daily].night[NEE_REF_Y] = rows_night_daily[row_daily].night_columns_y[ref_y];
+			rows_night_daily[row_daily].night_qc[NEE_REF_Y] = rows_night_daily[row_daily].night_qc_columns_y[ref_y];
+			rows_night_daily[row_daily].day[NEE_REF_Y] = rows_night_daily[row_daily].day_columns_y[ref_y];
+			rows_night_daily[row_daily].day_qc[NEE_REF_Y] = rows_night_daily[row_daily].day_qc_columns_y[ref_y];
 
-		/* update std */
-		nights_count = 0;
-		days_count = 0;
-		for ( i = 0; i < rows_per_day; i++ ) {
-			/* night ? */
-			index = row_daily*rows_per_day+i;
-			value = nee_matrix_y[index].nee[ref_y];
-			if ( ARE_FLOATS_EQUAL(dataset->rows[index].value[RPOT_VALUE], 0.0) ) {
-				if ( ! IS_INVALID_VALUE(value) ) {
-					nights[nights_count++] = value;
-				}				
-			} else {
-				if ( ! IS_INVALID_VALUE(value) ) {
-					days[days_count++] = value;				
+			/* update std */
+			nights_count = 0;
+			days_count = 0;
+			for ( i = 0; i < rows_per_day; i++ ) {
+				/* night ? */
+				index = row_daily*rows_per_day+i;
+				value = nee_matrix_y[index].nee[ref_y];
+				if ( ARE_FLOATS_EQUAL(dataset->rows[index].value[RPOT_VALUE], 0.0) ) {
+					if ( ! IS_INVALID_VALUE(value) ) {
+						nights[nights_count++] = value;
+					}				
+				} else {
+					if ( ! IS_INVALID_VALUE(value) ) {
+						days[days_count++] = value;				
+					}
 				}
 			}
-		}
 
-		if ( nights_count ) {
-			rows_night_daily[row_daily].night_std[NEE_REF_Y] = get_standard_deviation(nights, nights_count);
-		} else {
-			rows_night_daily[row_daily].night_std[NEE_REF_Y] = INVALID_VALUE;
-		}
+			if ( nights_count ) {
+				rows_night_daily[row_daily].night_std[NEE_REF_Y] = get_standard_deviation(nights, nights_count);
+			} else {
+				rows_night_daily[row_daily].night_std[NEE_REF_Y] = INVALID_VALUE;
+			}
 
-		if ( days_count ) {
-			rows_night_daily[row_daily].day_std[NEE_REF_Y] = get_standard_deviation(days, days_count);
-		} else {
-			rows_night_daily[row_daily].day_std[NEE_REF_Y] = INVALID_VALUE;
+			if ( days_count ) {
+				rows_night_daily[row_daily].day_std[NEE_REF_Y] = get_standard_deviation(days, days_count);
+			} else {
+				rows_night_daily[row_daily].day_std[NEE_REF_Y] = INVALID_VALUE;
+			}
 		}
 	}
 
@@ -2635,7 +2681,7 @@ static void update_ref(const DATASET *const dataset
 
 
 /* update ww percentiles and qcs */
-static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, const int rows_daily_count, ROW_NIGHT *const rows_weekly, const int rows_weekly_count) {
+static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, const int rows_daily_count, ROW_NIGHT *const rows_weekly, const int rows_weekly_count, const int skip_y) {
 	int i;
 	int ii;
 	int j;
@@ -2668,10 +2714,12 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 		for ( i = 0; i < 51; i++ ) {
 			row = i*7;
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_2-1; percentile++ ) {
-				rows_weekly[index+i].night_columns_y[percentile] = 0.0;
-				rows_weekly[index+i].day_columns_y[percentile] = 0.0;
-				rows_weekly[index+i].night_qc_columns_y[percentile] = 0.0;
-				rows_weekly[index+i].day_qc_columns_y[percentile] = 0.0;
+				if ( ! skip_y ) {
+					rows_weekly[index+i].night_columns_y[percentile] = 0.0;
+					rows_weekly[index+i].day_columns_y[percentile] = 0.0;
+					rows_weekly[index+i].night_qc_columns_y[percentile] = 0.0;
+					rows_weekly[index+i].day_qc_columns_y[percentile] = 0.0;
+				}
 				if ( dataset->years_count >= 3 ) {
 					rows_weekly[index+i].night_columns_c[percentile] = 0.0;
 					rows_weekly[index+i].day_columns_c[percentile] = 0.0;
@@ -2679,10 +2727,12 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 					rows_weekly[index+i].day_qc_columns_c[percentile] = 0.0;
 				}
 				for ( j = 0; j < 7; j++ ) {
-					rows_weekly[index+i].night_columns_y[percentile] += rows_daily[element+row+j].night_columns_y[percentile];
-					rows_weekly[index+i].day_columns_y[percentile] += rows_daily[element+row+j].day_columns_y[percentile];
-					rows_weekly[index+i].night_qc_columns_y[percentile] += rows_daily[element+row+j].night_qc_columns_y[percentile];
-					rows_weekly[index+i].day_qc_columns_y[percentile] += rows_daily[element+row+j].day_qc_columns_y[percentile];
+					if ( ! skip_y ) {
+						rows_weekly[index+i].night_columns_y[percentile] += rows_daily[element+row+j].night_columns_y[percentile];
+						rows_weekly[index+i].day_columns_y[percentile] += rows_daily[element+row+j].day_columns_y[percentile];
+						rows_weekly[index+i].night_qc_columns_y[percentile] += rows_daily[element+row+j].night_qc_columns_y[percentile];
+						rows_weekly[index+i].day_qc_columns_y[percentile] += rows_daily[element+row+j].day_qc_columns_y[percentile];
+					}
 					if ( dataset->years_count >= 3 ) {
 						rows_weekly[index+i].night_columns_c[percentile] += rows_daily[element+row+j].night_columns_c[percentile];
 						rows_weekly[index+i].day_columns_c[percentile] += rows_daily[element+row+j].day_columns_c[percentile];
@@ -2690,10 +2740,12 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 						rows_weekly[index+i].day_qc_columns_c[percentile] += rows_daily[element+row+j].day_qc_columns_c[percentile];
 					}
 				}
-				rows_weekly[index+i].night_columns_y[percentile] /= 7;
-				rows_weekly[index+i].day_columns_y[percentile] /= 7;
-				rows_weekly[index+i].night_qc_columns_y[percentile] /= 7;
-				rows_weekly[index+i].day_qc_columns_y[percentile] /= 7;
+				if ( ! skip_y ) {
+					rows_weekly[index+i].night_columns_y[percentile] /= 7;
+					rows_weekly[index+i].day_columns_y[percentile] /= 7;
+					rows_weekly[index+i].night_qc_columns_y[percentile] /= 7;
+					rows_weekly[index+i].day_qc_columns_y[percentile] /= 7;
+				}
 				if ( dataset->years_count >= 3 ) {
 					rows_weekly[index+i].night_columns_c[percentile] /= 7;
 					rows_weekly[index+i].day_columns_c[percentile] /= 7;
@@ -2705,21 +2757,25 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 		row += j; /* 51*7 */; 
 		z = y-row;
 		for ( percentile = 0; percentile < PERCENTILES_COUNT_2-1; percentile++ ) {
-			rows_weekly[index+i].night_columns_y[percentile] = 0.0;
+			if ( ! skip_y ) {
+				rows_weekly[index+i].night_columns_y[percentile] = 0.0;
 				rows_weekly[index+i].day_columns_y[percentile] = 0.0;
 				rows_weekly[index+i].night_qc_columns_y[percentile] = 0.0;
 				rows_weekly[index+i].day_qc_columns_y[percentile] = 0.0;
-				if ( dataset->years_count >= 3 ) {
-					rows_weekly[index+i].night_columns_c[percentile] = 0.0;
-					rows_weekly[index+i].day_columns_c[percentile] = 0.0;
-					rows_weekly[index+i].night_qc_columns_c[percentile] = 0.0;
-					rows_weekly[index+i].day_qc_columns_c[percentile] = 0.0;
-				}
+			}
+			if ( dataset->years_count >= 3 ) {
+				rows_weekly[index+i].night_columns_c[percentile] = 0.0;
+				rows_weekly[index+i].day_columns_c[percentile] = 0.0;
+				rows_weekly[index+i].night_qc_columns_c[percentile] = 0.0;
+				rows_weekly[index+i].day_qc_columns_c[percentile] = 0.0;
+			}
 			for ( j = 0; j < z; j++ ) {
-				rows_weekly[index+i].night_columns_y[percentile] += rows_daily[element+row+j].night_columns_y[percentile];
-				rows_weekly[index+i].day_columns_y[percentile] += rows_daily[element+row+j].day_columns_y[percentile];
-				rows_weekly[index+i].night_qc_columns_y[percentile] += rows_daily[element+row+j].night_qc_columns_y[percentile];
-				rows_weekly[index+i].day_qc_columns_y[percentile] += rows_daily[element+row+j].day_qc_columns_y[percentile];
+				if ( ! skip_y ) {
+					rows_weekly[index+i].night_columns_y[percentile] += rows_daily[element+row+j].night_columns_y[percentile];
+					rows_weekly[index+i].day_columns_y[percentile] += rows_daily[element+row+j].day_columns_y[percentile];
+					rows_weekly[index+i].night_qc_columns_y[percentile] += rows_daily[element+row+j].night_qc_columns_y[percentile];
+					rows_weekly[index+i].day_qc_columns_y[percentile] += rows_daily[element+row+j].day_qc_columns_y[percentile];
+				}
 				if ( dataset->years_count >= 3 ) {
 					rows_weekly[index+i].night_columns_c[percentile] += rows_daily[element+row+j].night_columns_c[percentile];
 					rows_weekly[index+i].day_columns_c[percentile] += rows_daily[element+row+j].day_columns_c[percentile];
@@ -2727,10 +2783,12 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 					rows_weekly[index+i].day_qc_columns_c[percentile] += rows_daily[element+row+j].day_qc_columns_c[percentile];
 				}
 			}
-			rows_weekly[index+i].night_columns_y[percentile] /= z;
-			rows_weekly[index+i].day_columns_y[percentile] /= z;
-			rows_weekly[index+i].night_qc_columns_y[percentile] /= z;
-			rows_weekly[index+i].day_qc_columns_y[percentile] /= z;
+			if ( ! skip_y ) {
+				rows_weekly[index+i].night_columns_y[percentile] /= z;
+				rows_weekly[index+i].day_columns_y[percentile] /= z;
+				rows_weekly[index+i].night_qc_columns_y[percentile] /= z;
+				rows_weekly[index+i].day_qc_columns_y[percentile] /= z;
+			}
 			if ( dataset->years_count >= 3 ) {
 				rows_weekly[index+i].night_columns_c[percentile] /= z;
 				rows_weekly[index+i].day_columns_c[percentile] /= z;
@@ -2747,37 +2805,39 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 	/* compute percentiles */
 	for ( i = 0; i < rows_weekly_count; ++i ) {
 		/* vut */
-		for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
-			/* night */
-			for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
-				percentiles[y] = rows_weekly[i].night_columns_y[y];
-				qcs[y] = rows_weekly[i].night_qc_columns_y[y];
-			}
-			rows_weekly[i].night[ii] = get_percentile_and_qc(percentiles
-															, qcs
-															, PERCENTILES_COUNT_2-1
-															, percentiles_test_1[ii-NEE_05_Y]
-															/* +7 for indexing QC */
-															, &rows_weekly[i].night[ii+7], &error);
-			if ( error ) {
-				printf("unable to get night ww %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				return 0;
-			}
+		if ( ! skip_y ) {
+			for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
+				/* night */
+				for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
+					percentiles[y] = rows_weekly[i].night_columns_y[y];
+					qcs[y] = rows_weekly[i].night_qc_columns_y[y];
+				}
+				rows_weekly[i].night[ii] = get_percentile_and_qc(percentiles
+																, qcs
+																, PERCENTILES_COUNT_2-1
+																, percentiles_test_1[ii-NEE_05_Y]
+																/* +7 for indexing QC */
+																, &rows_weekly[i].night[ii+7], &error);
+				if ( error ) {
+					printf("unable to get night ww %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					return 0;
+				}
 
-			/* day */
-			for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
-				percentiles[y] = rows_weekly[i].day_columns_y[y];
-				qcs[y] = rows_weekly[i].day_qc_columns_y[y];
-			}
-			rows_weekly[i].day[ii] = get_percentile_and_qc(percentiles
-															, qcs
-															, PERCENTILES_COUNT_2-1
-															, percentiles_test_1[ii-NEE_05_Y]
-															/* +7 for indexing QC */
-															, &rows_weekly[i].day[ii+7], &error);
-			if ( error ) {
-				printf("unable to get day ww %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				return 0;
+				/* day */
+				for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
+					percentiles[y] = rows_weekly[i].day_columns_y[y];
+					qcs[y] = rows_weekly[i].day_qc_columns_y[y];
+				}
+				rows_weekly[i].day[ii] = get_percentile_and_qc(percentiles
+																, qcs
+																, PERCENTILES_COUNT_2-1
+																, percentiles_test_1[ii-NEE_05_Y]
+																/* +7 for indexing QC */
+																, &rows_weekly[i].day[ii+7], &error);
+				if ( error ) {
+					printf("unable to get day ww %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					return 0;
+				}
 			}
 		}
 
@@ -2822,7 +2882,7 @@ static int update_ww(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 }
 
 /* update mm percentiles and qcs */
-static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, const int rows_daily_count, ROW_NIGHT *const rows_monthly, const int rows_monthly_count) {
+static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, const int rows_daily_count, ROW_NIGHT *const rows_monthly, const int rows_monthly_count, const int skip_y) {
 	int i;
 	int ii;
 	int j;
@@ -2843,10 +2903,12 @@ static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 	for ( row = 0; row < rows_daily_count; ) {
 		for ( i = 0; i < 12; i++ ) {
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_2-1; percentile++ ) {
-				rows_monthly[index+i].night_columns_y[percentile] = 0.0;
-				rows_monthly[index+i].day_columns_y[percentile] = 0.0;
-				rows_monthly[index+i].night_qc_columns_y[percentile] = 0.0;
-				rows_monthly[index+i].day_qc_columns_y[percentile] = 0.0;
+				if ( ! skip_y ) {
+					rows_monthly[index+i].night_columns_y[percentile] = 0.0;
+					rows_monthly[index+i].day_columns_y[percentile] = 0.0;
+					rows_monthly[index+i].night_qc_columns_y[percentile] = 0.0;
+					rows_monthly[index+i].day_qc_columns_y[percentile] = 0.0;
+				}
 				if ( dataset->years_count >= 3 ) {
 					rows_monthly[index+i].night_columns_c[percentile] = 0.0;
 					rows_monthly[index+i].day_columns_c[percentile] = 0.0;
@@ -2858,10 +2920,12 @@ static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 					++z;
 				}
 				for ( j = 0; j < z; j++ ) {
-					rows_monthly[index+i].night_columns_y[percentile] += rows_daily[row+j].night_columns_y[percentile];
-					rows_monthly[index+i].day_columns_y[percentile] += rows_daily[row+j].day_columns_y[percentile];
-					rows_monthly[index+i].night_qc_columns_y[percentile] += rows_daily[row+j].night_qc_columns_y[percentile];
-					rows_monthly[index+i].day_qc_columns_y[percentile] += rows_daily[row+j].day_qc_columns_y[percentile];
+					if ( ! skip_y ) {
+						rows_monthly[index+i].night_columns_y[percentile] += rows_daily[row+j].night_columns_y[percentile];
+						rows_monthly[index+i].day_columns_y[percentile] += rows_daily[row+j].day_columns_y[percentile];
+						rows_monthly[index+i].night_qc_columns_y[percentile] += rows_daily[row+j].night_qc_columns_y[percentile];
+						rows_monthly[index+i].day_qc_columns_y[percentile] += rows_daily[row+j].day_qc_columns_y[percentile];
+					}
 					if ( dataset->years_count >= 3 ) {
 						rows_monthly[index+i].night_columns_c[percentile] += rows_daily[row+j].night_columns_c[percentile];
 						rows_monthly[index+i].day_columns_c[percentile] += rows_daily[row+j].day_columns_c[percentile];
@@ -2869,10 +2933,12 @@ static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 						rows_monthly[index+i].day_qc_columns_c[percentile] += rows_daily[row+j].day_qc_columns_c[percentile];
 					}
 				}
-				rows_monthly[index+i].night_columns_y[percentile] /= z;
-				rows_monthly[index+i].day_columns_y[percentile] /= z;
-				rows_monthly[index+i].night_qc_columns_y[percentile] /= z;
-				rows_monthly[index+i].day_qc_columns_y[percentile] /= z;
+				if ( ! skip_y ) {
+					rows_monthly[index+i].night_columns_y[percentile] /= z;
+					rows_monthly[index+i].day_columns_y[percentile] /= z;
+					rows_monthly[index+i].night_qc_columns_y[percentile] /= z;
+					rows_monthly[index+i].day_qc_columns_y[percentile] /= z;
+				}
 				if ( dataset->years_count >= 3 ) {
 					rows_monthly[index+i].night_columns_c[percentile] /= z;
 					rows_monthly[index+i].day_columns_c[percentile] /= z;
@@ -2889,37 +2955,39 @@ static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 	/* compute percentiles */
 	for ( i = 0; i < rows_monthly_count; ++i ) {
 		/* vut */
-		for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
-			/* night */
-			for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
-				percentiles[y] = rows_monthly[i].night_columns_y[y];
-				qcs[y] = rows_monthly[i].night_qc_columns_y[y];
-			}
-			rows_monthly[i].night[ii] = get_percentile_and_qc(percentiles
-															, qcs
-															, PERCENTILES_COUNT_2-1
-															, percentiles_test_1[ii-NEE_05_Y]
-															/* +7 for indexing QC */
-															, &rows_monthly[i].night[ii+7], &error);
-			if ( error ) {
-				printf("unable to get night mm %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				return 0;
-			}
+		if ( ! skip_y ) {
+			for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
+				/* night */
+				for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
+					percentiles[y] = rows_monthly[i].night_columns_y[y];
+					qcs[y] = rows_monthly[i].night_qc_columns_y[y];
+				}
+				rows_monthly[i].night[ii] = get_percentile_and_qc(percentiles
+																, qcs
+																, PERCENTILES_COUNT_2-1
+																, percentiles_test_1[ii-NEE_05_Y]
+																/* +7 for indexing QC */
+																, &rows_monthly[i].night[ii+7], &error);
+				if ( error ) {
+					printf("unable to get night mm %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					return 0;
+				}
 
-			/* day */
-			for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
-				percentiles[y] = rows_monthly[i].day_columns_y[y];
-				qcs[y] = rows_monthly[i].day_qc_columns_y[y];
-			}
-			rows_monthly[i].day[ii] = get_percentile_and_qc(percentiles
-															, qcs
-															, PERCENTILES_COUNT_2-1
-															, percentiles_test_1[ii-NEE_05_Y]
-															/* +7 for indexing QC */
-															, &rows_monthly[i].day[ii+7], &error);
-			if ( error ) {
-				printf("unable to get day mm %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				return 0;
+				/* day */
+				for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
+					percentiles[y] = rows_monthly[i].day_columns_y[y];
+					qcs[y] = rows_monthly[i].day_qc_columns_y[y];
+				}
+				rows_monthly[i].day[ii] = get_percentile_and_qc(percentiles
+																, qcs
+																, PERCENTILES_COUNT_2-1
+																, percentiles_test_1[ii-NEE_05_Y]
+																/* +7 for indexing QC */
+																, &rows_monthly[i].day[ii+7], &error);
+				if ( error ) {
+					printf("unable to get day mm %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					return 0;
+				}
 			}
 		}
 
@@ -2965,7 +3033,7 @@ static int update_mm(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 
 
 /* update yy percentiles and qcs */
-static int update_yy(const DATASET *dataset, const ROW_NIGHT *const rows_daily, const int rows_daily_count, ROW_NIGHT *const rows_yearly, const int rows_yearly_count) {
+static int update_yy(const DATASET *dataset, const ROW_NIGHT *const rows_daily, const int rows_daily_count, ROW_NIGHT *const rows_yearly, const int rows_yearly_count, const int skip_y) {
 	int i;
 	int ii;
 	int j;
@@ -2985,10 +3053,12 @@ static int update_yy(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 	for ( row = 0; row < rows_daily_count; ) {
 		y = IS_LEAP_YEAR(year) ? 366 : 365;
 		for ( percentile = 0; percentile < PERCENTILES_COUNT_2-1; percentile++ ) {
-			rows_yearly[index].night_columns_y[percentile] = 0.0;
-			rows_yearly[index].day_columns_y[percentile] = 0.0;
-			rows_yearly[index].night_qc_columns_y[percentile] = 0.0;
-			rows_yearly[index].day_qc_columns_y[percentile] = 0.0;
+			if ( ! skip_y ) {
+				rows_yearly[index].night_columns_y[percentile] = 0.0;
+				rows_yearly[index].day_columns_y[percentile] = 0.0;
+				rows_yearly[index].night_qc_columns_y[percentile] = 0.0;
+				rows_yearly[index].day_qc_columns_y[percentile] = 0.0;
+			}
 			if ( dataset->years_count >= 3 ) {
 				rows_yearly[index].night_columns_c[percentile] = 0.0;
 				rows_yearly[index].day_columns_c[percentile] = 0.0;
@@ -2996,10 +3066,12 @@ static int update_yy(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 				rows_yearly[index].day_qc_columns_c[percentile] = 0.0;
 			}
 			for ( j = 0; j < y; j++ ) {
-				rows_yearly[index].night_columns_y[percentile] += rows_daily[row+j].night_columns_y[percentile];
-				rows_yearly[index].day_columns_y[percentile] += rows_daily[row+j].day_columns_y[percentile];
-				rows_yearly[index].night_qc_columns_y[percentile] += rows_daily[row+j].night_qc_columns_y[percentile];
-				rows_yearly[index].day_qc_columns_y[percentile] += rows_daily[row+j].day_qc_columns_y[percentile];
+				if ( ! skip_y ) {
+					rows_yearly[index].night_columns_y[percentile] += rows_daily[row+j].night_columns_y[percentile];
+					rows_yearly[index].day_columns_y[percentile] += rows_daily[row+j].day_columns_y[percentile];
+					rows_yearly[index].night_qc_columns_y[percentile] += rows_daily[row+j].night_qc_columns_y[percentile];
+					rows_yearly[index].day_qc_columns_y[percentile] += rows_daily[row+j].day_qc_columns_y[percentile];
+				}
 				if ( dataset->years_count >= 3 ) {
 					rows_yearly[index].night_columns_c[percentile] += rows_daily[row+j].night_columns_c[percentile];
 					rows_yearly[index].day_columns_c[percentile] += rows_daily[row+j].day_columns_c[percentile];
@@ -3007,10 +3079,12 @@ static int update_yy(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 					rows_yearly[index].day_qc_columns_c[percentile] += rows_daily[row+j].day_qc_columns_c[percentile];
 				}
 			}
-			rows_yearly[index].night_columns_y[percentile] /= y;
-			rows_yearly[index].day_columns_y[percentile] /= y;
-			rows_yearly[index].night_qc_columns_y[percentile] /= y;
-			rows_yearly[index].day_qc_columns_y[percentile] /= y;
+			if ( ! skip_y ) {
+				rows_yearly[index].night_columns_y[percentile] /= y;
+				rows_yearly[index].day_columns_y[percentile] /= y;
+				rows_yearly[index].night_qc_columns_y[percentile] /= y;
+				rows_yearly[index].day_qc_columns_y[percentile] /= y;
+			}
 			if ( dataset->years_count >= 3 ) {
 				rows_yearly[index].night_columns_c[percentile] /= y;
 				rows_yearly[index].day_columns_c[percentile] /= y;
@@ -3026,37 +3100,39 @@ static int update_yy(const DATASET *dataset, const ROW_NIGHT *const rows_daily, 
 	/* compute percentiles */
 	for ( i = 0; i < rows_yearly_count; ++i ) {
 		/* vut */
-		for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
-			/* night */
-			for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
-				percentiles[y] = rows_yearly[i].night_columns_y[y];
-				qcs[y] = rows_yearly[i].night_qc_columns_y[y];
-			}
-			rows_yearly[i].night[ii] = get_percentile_and_qc(percentiles
-															, qcs
-															, PERCENTILES_COUNT_2-1
-															, percentiles_test_1[ii-NEE_05_Y]
-															/* +7 for indexing QC */
-															, &rows_yearly[i].night[ii+7], &error);
-			if ( error ) {
-				printf("unable to get night yy %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				return 0;
-			}
+		if ( ! skip_y ) {
+			for ( ii = NEE_05_Y; ii <= NEE_95_Y; ii++ ) {
+				/* night */
+				for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
+					percentiles[y] = rows_yearly[i].night_columns_y[y];
+					qcs[y] = rows_yearly[i].night_qc_columns_y[y];
+				}
+				rows_yearly[i].night[ii] = get_percentile_and_qc(percentiles
+																, qcs
+																, PERCENTILES_COUNT_2-1
+																, percentiles_test_1[ii-NEE_05_Y]
+																/* +7 for indexing QC */
+																, &rows_yearly[i].night[ii+7], &error);
+				if ( error ) {
+					printf("unable to get night yy %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					return 0;
+				}
 
-			/* day */
-			for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
-				percentiles[y] = rows_yearly[i].day_columns_y[y];
-				qcs[y] = rows_yearly[i].day_qc_columns_y[y];
-			}
-			rows_yearly[i].day[ii] = get_percentile_and_qc(percentiles
-															, qcs
-															, PERCENTILES_COUNT_2-1
-															, percentiles_test_1[ii-NEE_05_Y]
-															/* +7 for indexing QC */
-															, &rows_yearly[i].day[ii+7], &error);
-			if ( error ) {
-				printf("unable to get day yy %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
-				return 0;
+				/* day */
+				for ( y = 0; y < PERCENTILES_COUNT_2-1; ++y ) {
+					percentiles[y] = rows_yearly[i].day_columns_y[y];
+					qcs[y] = rows_yearly[i].day_qc_columns_y[y];
+				}
+				rows_yearly[i].day[ii] = get_percentile_and_qc(percentiles
+																, qcs
+																, PERCENTILES_COUNT_2-1
+																, percentiles_test_1[ii-NEE_05_Y]
+																/* +7 for indexing QC */
+																, &rows_yearly[i].day[ii+7], &error);
+				if ( error ) {
+					printf("unable to get day yy %g %%percentile for y!\n", percentiles_test_1[ii-NEE_05_Y]);
+					return 0;
+				}
 			}
 		}
 
@@ -3112,16 +3188,20 @@ static int compute_rand_unc(const DATASET *const dataset
 	/* build-up dataset */
 	for ( i = 0; i < dataset->rows_count; i++ ) {
 		unc_rows[i].mask = 0;
-		unc_rows[i].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
-		unc_rows[i].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+		if ( nee_matrix_y ) {
+			unc_rows[i].rand[NEE_REF_Y_UNC] = INVALID_VALUE;
+			unc_rows[i].rand[NEE_UST50_Y_UNC] = INVALID_VALUE;
+		}
 		unc_rows[i].rand[NEE_REF_C_UNC] = INVALID_VALUE;
 		unc_rows[i].rand[NEE_UST50_C_UNC] = INVALID_VALUE;
 
-		unc_rows[i].value[NEE_REF_Y_UNC] = nee_matrix_y[i].nee[ref_y];
-		unc_rows[i].qc[NEE_REF_Y_UNC] = nee_matrix_y[i].qc[ref_y];
+		if ( nee_matrix_y ) {
+			unc_rows[i].value[NEE_REF_Y_UNC] = nee_matrix_y[i].nee[ref_y];
+			unc_rows[i].qc[NEE_REF_Y_UNC] = nee_matrix_y[i].qc[ref_y];
 
-		unc_rows[i].value[NEE_UST50_Y_UNC] = nee_matrix_y[i].nee[PERCENTILES_COUNT_2-1];
-		unc_rows[i].qc[NEE_UST50_Y_UNC] = nee_matrix_y[i].qc[PERCENTILES_COUNT_2-1];
+			unc_rows[i].value[NEE_UST50_Y_UNC] = nee_matrix_y[i].nee[PERCENTILES_COUNT_2-1];
+			unc_rows[i].qc[NEE_UST50_Y_UNC] = nee_matrix_y[i].qc[PERCENTILES_COUNT_2-1];
+		}
 
 		if ( dataset->years_count >= 3 ) {
 			unc_rows[i].value[NEE_REF_C_UNC] = nee_matrix_c[i].nee[ref_c];
@@ -3132,8 +3212,10 @@ static int compute_rand_unc(const DATASET *const dataset
 		}
 
 		/* update mask */
-		if ( !IS_INVALID_VALUE(unc_rows[i].value[NEE_REF_Y_UNC]) ) {
-			unc_rows[i].mask |= GF_TOFILL_VALID;
+		if ( nee_matrix_y ) {
+			if ( !IS_INVALID_VALUE(unc_rows[i].value[NEE_REF_Y_UNC]) ) {
+				unc_rows[i].mask |= GF_TOFILL_VALID;
+			}
 		}
 
 		unc_rows[i].value[SWIN_UNC] = dataset->rows[i].value[SWIN_VALUE];
@@ -3150,14 +3232,16 @@ static int compute_rand_unc(const DATASET *const dataset
 		}
 
 		/* set methods */
-		unc_rows[i].method[NEE_REF_Y_UNC] = 1;
-		if ( unc_rows[i].qc[NEE_REF_Y_UNC] ) {
-			unc_rows[i].method[NEE_REF_Y_UNC] = 2;
-		}
+		if ( nee_matrix_y ) {
+			unc_rows[i].method[NEE_REF_Y_UNC] = 1;
+			if ( unc_rows[i].qc[NEE_REF_Y_UNC] ) {
+				unc_rows[i].method[NEE_REF_Y_UNC] = 2;
+			}
 
-		unc_rows[i].method[NEE_UST50_Y_UNC] = 1;
-		if ( unc_rows[i].qc[NEE_UST50_Y_UNC] ) {
-			unc_rows[i].method[NEE_UST50_Y_UNC] = 2;
+			unc_rows[i].method[NEE_UST50_Y_UNC] = 1;
+			if ( unc_rows[i].qc[NEE_UST50_Y_UNC] ) {
+				unc_rows[i].method[NEE_UST50_Y_UNC] = 2;
+			}
 		}
 
 		if ( dataset->years_count >= 3 ) {
@@ -3174,24 +3258,26 @@ static int compute_rand_unc(const DATASET *const dataset
 	}
 	
 	/* compute random uncertainty */
-	random_method_1(unc_rows, dataset->rows_count, NEE_REF_Y_UNC, HOURLY_TIMERES == dataset->details->timeres);
-	if ( ! random_method_2(unc_rows, dataset->rows_count, NEE_REF_Y_UNC, HOURLY_TIMERES == dataset->details->timeres) ) {
-		return 0;
-	}
-
-	/* update mask */
-	for ( i = 0; i < dataset->rows_count; i++ ) {
-		/* clear bit */
-		unc_rows[i].mask &= ~(GF_TOFILL_VALID);
-		/* set */
-		if ( ! IS_INVALID_VALUE(unc_rows[i].value[NEE_UST50_Y_UNC]) ) {
-			unc_rows[i].mask |= GF_TOFILL_VALID;
+	if ( nee_matrix_y ) {
+		random_method_1(unc_rows, dataset->rows_count, NEE_REF_Y_UNC, HOURLY_TIMERES == dataset->details->timeres);
+		if ( ! random_method_2(unc_rows, dataset->rows_count, NEE_REF_Y_UNC, HOURLY_TIMERES == dataset->details->timeres) ) {
+			return 0;
 		}
-	}
 
-	random_method_1(unc_rows, dataset->rows_count, NEE_UST50_Y_UNC, HOURLY_TIMERES == dataset->details->timeres);
-	if ( ! random_method_2(unc_rows, dataset->rows_count, NEE_UST50_Y_UNC, HOURLY_TIMERES == dataset->details->timeres) ) {
-		return 0;
+		/* update mask */
+		for ( i = 0; i < dataset->rows_count; i++ ) {
+			/* clear bit */
+			unc_rows[i].mask &= ~(GF_TOFILL_VALID);
+			/* set */
+			if ( ! IS_INVALID_VALUE(unc_rows[i].value[NEE_UST50_Y_UNC]) ) {
+				unc_rows[i].mask |= GF_TOFILL_VALID;
+			}
+		}
+
+		random_method_1(unc_rows, dataset->rows_count, NEE_UST50_Y_UNC, HOURLY_TIMERES == dataset->details->timeres);
+		if ( ! random_method_2(unc_rows, dataset->rows_count, NEE_UST50_Y_UNC, HOURLY_TIMERES == dataset->details->timeres) ) {
+			return 0;
+		}
 	}
 
 	if ( dataset->years_count >= 3 ) {
@@ -3344,6 +3430,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 	int on_error;
 	int valid_values_count_night;
 	int valid_values_count_day;
+	int skip_y;
 	char buffer[BUFFER_SIZE];
 	char buffer2[BUFFER_SIZE];
 	char *p;
@@ -4035,6 +4122,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		*
 		*/
 
+		skip_y = 0;
+
 		/* loop for each percentile */
 		for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
 			/* reset */
@@ -4055,23 +4144,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 					percentiles_y[year].value[percentile] = get_percentile(uts, uts_count, percentiles_test_2[percentile], &error);
 					if ( error ) {
 						printf("unable to get percentile for %d in y method.\n", datasets[dataset].years[year].year);
-						if ( compute_nee_flags ) {
-							if ( datasets[dataset].years_count >= 3 ) {
-								free(nee_flags_c);
-							}
-							free(nee_flags_y);
-						}
-						free(unc_rows_temp);
-						free(unc_rows_aggr);
-						free(unc_rows);
-						free(nee_matrix_y);
-						if ( datasets[dataset].years_count >= 3 ) {
-							free(nee_matrix_c);
-						}
-						free(percentiles_y);
-						free(uts);
-						free(rows_copy);
 						on_error = 1;
+						skip_y = 1;
 						break;
 					}
 					printf("%d -> filtering for %g (%g%%)...", datasets[dataset].years[year].year, percentiles_y[year].value[percentile], percentiles_test_2[percentile]);
@@ -4111,6 +4185,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 					printf("%g NEE values removed.\n", (PREC)element/rows_count);
 				} else {
 					printf("%d -> filtering is not possible\n", datasets[dataset].years[year].year);
+					on_error = 1;
+					break;
 				}
 
 				/* update */
@@ -4216,54 +4292,73 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			datasets[dataset].gf_rows = NULL;
 		}
 
-		if ( on_error ) {
-			continue;
+		if ( skip_y ) {
+			free(nee_matrix_y);
+			free(percentiles_y);
+			nee_matrix_y = NULL;
+			percentiles_y = NULL;
+			if ( datasets[dataset].years_count < 3 ) {
+				if ( compute_nee_flags ) {
+					free(nee_flags_y);
+				}
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(uts);
+				free(rows_copy);
+				continue;
+			}
 		}
 
-		/* save _y percentiles */
-		printf("saving y u* percentiles...");
-		sprintf(buffer, "%s%s_USTAR_percentiles_y.csv", output_files_path, datasets[dataset].details->site);
-		f = fopen(buffer, "w");
-		if ( !f ) {
-			puts("unable to create file!\n");
-			if ( compute_nee_flags ) {
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_flags_c);
+		if ( ! on_error ) {
+			/* save _y percentiles */
+			printf("saving y u* percentiles...");
+			sprintf(buffer, "%s%s_USTAR_percentiles_y.csv", output_files_path, datasets[dataset].details->site);
+			f = fopen(buffer, "w");
+			if ( !f ) {
+				puts("unable to create file!\n");
+				if ( compute_nee_flags ) {
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_flags_c);
+					}
+					free(nee_flags_y);
 				}
-				free(nee_flags_y);
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(nee_matrix_y);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c);
+				}
+				free(percentiles_y);
+				free(uts);
+				free(rows_copy);
+				continue;
 			}
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(nee_matrix_y);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c);
-			}
-			free(percentiles_y);
-			free(uts);
-			free(rows_copy);
-			continue;
-		}
-		fprintf(f, "%s,", TIMESTAMP_STRING);
-		for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-			fprintf(f, "%g", percentiles_test_2[percentile]);
-			if ( percentile < PERCENTILES_COUNT_2-1 ) {
-				fputs(",", f);
-			}
-		}
-		fputs("\n", f);
-		for ( year = 0; year < datasets[dataset].years_count; year++ ) {
-			fprintf(f, "%d,", datasets[dataset].years[year].year);
+			fprintf(f, "%s,", TIMESTAMP_STRING);
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-				fprintf(f, "%g", percentiles_y[year].value[percentile]);
+				fprintf(f, "%g", percentiles_test_2[percentile]);
 				if ( percentile < PERCENTILES_COUNT_2-1 ) {
 					fputs(",", f);
 				}
 			}
 			fputs("\n", f);
+			for ( year = 0; year < datasets[dataset].years_count; year++ ) {
+				fprintf(f, "%d,", datasets[dataset].years[year].year);
+				for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
+					fprintf(f, "%g", percentiles_y[year].value[percentile]);
+					if ( percentile < PERCENTILES_COUNT_2-1 ) {
+						fputs(",", f);
+					}
+				}
+				fputs("\n", f);
+			}
+			fclose(f);
+			puts("ok");
 		}
-		fclose(f);
-		puts("ok");
+
+		/* reset error state */
+		on_error = 0;
 
 		/*
 		*
@@ -4515,16 +4610,21 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 
 		/* saving y nee matrix */
-		if ( ! save_nee_matrix(nee_matrix_y, &datasets[dataset], HH_Y) ) {
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(nee_matrix_y);
-			free(percentiles_y);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c);
+		if ( ! skip_y ) {
+			if ( ! save_nee_matrix(nee_matrix_y, &datasets[dataset], HH_Y) ) {
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(nee_matrix_y);
+				free(percentiles_y);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c);
+				}
+				continue;
 			}
-			continue;
+		} else if ( nee_matrix_y ) {
+			free(nee_matrix_y);
+			nee_matrix_y = NULL;
 		}
 
 		/* saving c nee matrix */
@@ -4541,18 +4641,22 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 
 		/* process nee_matrix y */
-		p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y, datasets[dataset].rows_count, &ref_y, HH_Y);
-		ref_y_old = ref_y;
-		if ( ! p_matrix_y ) {
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(percentiles_y);
-			free(nee_matrix_y);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c);
+		if ( ! skip_y ) {
+			p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y, datasets[dataset].rows_count, &ref_y, HH_Y);
+			ref_y_old = ref_y;
+			if ( ! p_matrix_y ) {
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(percentiles_y);
+				free(nee_matrix_y);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			p_matrix_y = NULL;
 		}
 
 		/* process nee_matrix c */
@@ -4595,10 +4699,14 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			}
 
 			/* write header */
-			if ( datasets[dataset].years_count >= 3 ) {
-				fprintf(f, "%s,NEE_FLAG_Y_REF,NEE_FLAG_Y_UST50,NEE_FLAG_C_REF,NEE_FLAG_C_UST50\n", TIMESTAMP_HEADER);
+			if ( ! skip_y ) {
+				if ( datasets[dataset].years_count >= 3 ) {
+					fprintf(f, "%s,NEE_FLAG_Y_REF,NEE_FLAG_Y_UST50,NEE_FLAG_C_REF,NEE_FLAG_C_UST50\n", TIMESTAMP_HEADER);
+				} else {
+					fprintf(f, "%s,NEE_FLAG_Y_REF,NEE_FLAG_Y_UST50\n", TIMESTAMP_HEADER);
+				}
 			} else {
-				fprintf(f, "%s,NEE_FLAG_Y_REF,NEE_FLAG_Y_UST50\n", TIMESTAMP_HEADER);
+				fprintf(f, "%s,NEE_FLAG_C_REF,NEE_FLAG_C_UST50\n", TIMESTAMP_HEADER);
 			}
 
 			j = 0;
@@ -4614,7 +4722,9 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 					fprintf(f, "%04d%02d%02d%02d%02d,", t->YYYY, t->MM, t->DD, t->hh, t->mm);
 					t = timestamp_end_by_row(row, datasets[dataset].years[i].year, datasets[dataset].details->timeres);
 					fprintf(f, "%04d%02d%02d%02d%02d,", t->YYYY, t->MM, t->DD, t->hh, t->mm);
-					fprintf(f, "%d,%d", nee_flags_y[j+row].value[ref_y], nee_flags_y[j+row].value[PERCENTILES_COUNT_2-1]);
+					if ( ! skip_y ) {
+						fprintf(f, "%d,%d", nee_flags_y[j+row].value[ref_y], nee_flags_y[j+row].value[PERCENTILES_COUNT_2-1]);
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						fprintf(f, ",%d,%d", nee_flags_c[j+row].value[ref_c], nee_flags_c[j+row].value[PERCENTILES_COUNT_2-1]);
 					}
@@ -4680,22 +4790,25 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* write header hh */
 		fprintf(f, header_file_hh, TIMESTAMP_HEADER);
-		if ( no_rand_unc ) {
-			fputs(output_var_1, f);
-		} else {
-			fputs(output_var_1_rand_unc_hh, f);
-		}
-		for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
-			fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
-			if ( percentile < PERCENTILES_COUNT_1-1 ) {
-				fputs(",", f);
+		if ( ! skip_y ) {
+			if ( no_rand_unc ) {
+				fputs(output_var_1, f);
+			} else {
+				fputs(output_var_1_rand_unc_hh, f);
+			}
+			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
+				fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
+				if ( percentile < PERCENTILES_COUNT_1-1 ) {
+					fputs(",", f);
+				}
 			}
 		}
+
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(output_var_2, f);
+				fputs(output_var_2 + skip_y, f);
 			} else {
-				fputs(output_var_2_rand_unc_hh, f);
+				fputs(output_var_2_rand_unc_hh + skip_y, f);
 			}
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
 				fprintf(f, "NEE_%02g_c,NEE_%02g_qc_c", percentiles_test_1[percentile],percentiles_test_1[percentile]);
@@ -4728,83 +4841,86 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				fprintf(f, "%g,", get_dtime_by_row(row, (HOURLY_TIMERES == datasets[dataset].details->timeres)));
 				/* rpot */
 				fprintf(f, "%d,", ARE_FLOATS_EQUAL(datasets[dataset].rows[j+row].value[RPOT_VALUE], 0.0) ? 1 : 0);
-				/* */
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-																nee_matrix_y[j+row].nee[ref_y],
-																nee_matrix_y[j+row].qc[ref_y],
-																nee_matrix_y[j+row].nee[PERCENTILES_COUNT_2-1],
-																nee_matrix_y[j+row].qc[PERCENTILES_COUNT_2-1],
-																p_matrix_y[j+row].mean,
-																p_matrix_y[j+row].mean_qc,
-																p_matrix_y[j+row].std_err
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																	nee_matrix_y[j+row].nee[ref_y],
+																	nee_matrix_y[j+row].qc[ref_y],
+																	nee_matrix_y[j+row].nee[PERCENTILES_COUNT_2-1],
+																	nee_matrix_y[j+row].qc[PERCENTILES_COUNT_2-1],
+																	p_matrix_y[j+row].mean,
+																	p_matrix_y[j+row].mean_qc,
+																	p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",		(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",		(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_joinUnc_y = compute_join(unc_rows[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							nee_ust50_joinUnc_y = compute_join(unc_rows[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							fprintf(f, "%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
+																	nee_matrix_y[j+row].nee[ref_y],
+																	nee_matrix_y[j+row].qc[ref_y],
+																	unc_rows[j+row].rand[NEE_REF_Y_UNC],
+																	unc_rows[j+row].method[NEE_REF_Y_UNC],
+																	unc_rows[j+row].samples_count[NEE_REF_Y_UNC],
+																	nee_ref_joinUnc_y,
+																	nee_matrix_y[j+row].nee[PERCENTILES_COUNT_2-1],
+																	nee_matrix_y[j+row].qc[PERCENTILES_COUNT_2-1],
+																	unc_rows[j+row].rand[NEE_UST50_Y_UNC],
+																	unc_rows[j+row].method[NEE_UST50_Y_UNC],
+																	unc_rows[j+row].samples_count[NEE_UST50_Y_UNC],
+																	nee_ust50_joinUnc_y,
+																	p_matrix_y[j+row].mean,
+																	p_matrix_y[j+row].mean_qc,
+																	p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	INVALID_VALUE,
+																	INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	INVALID_VALUE,
+																	INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE
+							);
+						}
 					}
-				} else {
-					if ( exists ) {
-						nee_ref_joinUnc_y = compute_join(unc_rows[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						nee_ust50_joinUnc_y = compute_join(unc_rows[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						fprintf(f, "%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
-																nee_matrix_y[j+row].nee[ref_y],
-																nee_matrix_y[j+row].qc[ref_y],
-																unc_rows[j+row].rand[NEE_REF_Y_UNC],
-																unc_rows[j+row].method[NEE_REF_Y_UNC],
-																unc_rows[j+row].samples_count[NEE_REF_Y_UNC],
-																nee_ref_joinUnc_y,
-																nee_matrix_y[j+row].nee[PERCENTILES_COUNT_2-1],
-																nee_matrix_y[j+row].qc[PERCENTILES_COUNT_2-1],
-																unc_rows[j+row].rand[NEE_UST50_Y_UNC],
-																unc_rows[j+row].method[NEE_UST50_Y_UNC],
-																unc_rows[j+row].samples_count[NEE_UST50_Y_UNC],
-																nee_ust50_joinUnc_y,
-																p_matrix_y[j+row].mean,
-																p_matrix_y[j+row].mean_qc,
-																p_matrix_y[j+row].std_err
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																INVALID_VALUE,
-																INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																INVALID_VALUE,
-																INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE
-						);
+					for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
+						} else {
+							fprintf(f, "%g,%g", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+						}
+						if ( z < PERCENTILES_COUNT_1-1 ) {
+							fputs(",", f);
+						}
 					}
 				}
-				for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
-					} else {
-						fprintf(f, "%g,%g", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
-					}
-					if ( z < PERCENTILES_COUNT_1-1 ) {
-						fputs(",", f);
-					}
-				}
+
 				if ( datasets[dataset].years_count >= 3 ) {
 					if ( no_rand_unc ) {
 						if ( exists ) {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,",
+																skip_y ? "" : ",",
 																nee_matrix_c[j+row].nee[ref_c],
 																nee_matrix_c[j+row].qc[ref_c],
 																nee_matrix_c[j+row].nee[PERCENTILES_COUNT_2-1],
@@ -4814,7 +4930,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 																p_matrix_c[j+row].std_err
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,",
+																skip_y ? "" : ",",
 																(PREC)INVALID_VALUE,
 																(PREC)INVALID_VALUE,
 																(PREC)INVALID_VALUE,
@@ -4828,7 +4945,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 						if ( exists ) {
 							nee_ref_joinUnc_c = compute_join(unc_rows[j+row].rand[NEE_REF_C_UNC], p_matrix_c[j+row].value[1], p_matrix_c[j+row].value[5]);
 							nee_ust50_joinUnc_c = compute_join(unc_rows[j+row].rand[NEE_UST50_C_UNC], p_matrix_c[j+row].value[1], p_matrix_c[j+row].value[5]);
-							fprintf(f, ",%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
+							fprintf(f, "%s%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
+																skip_y ? "" : ",",
 																nee_matrix_c[j+row].nee[ref_c],
 																nee_matrix_c[j+row].qc[ref_c],
 																unc_rows[j+row].rand[NEE_REF_C_UNC],
@@ -4846,7 +4964,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 																p_matrix_c[j+row].std_err
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
+							fprintf(f, "%s%g,%g,%g,%d,%d,%g,%g,%g,%g,%d,%d,%g,%g,%g,%g,",
+																skip_y ? "" : ",",
 																(PREC)INVALID_VALUE,
 																(PREC)INVALID_VALUE,
 																(PREC)INVALID_VALUE,
@@ -4922,20 +5041,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		daily_rows_count = datasets[dataset].rows_count / rows_per_day;
 
 		/* alloc memory for daily */
-		nee_matrix_y_daily = malloc(daily_rows_count*sizeof*nee_matrix_y_daily);
-		if ( !nee_matrix_y_daily ) {
-			puts(err_out_of_memory);
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(percentiles_y);
-			free(p_matrix_y);
-			free(nee_matrix_y);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(p_matrix_c);
-				free(nee_matrix_c);
+		if ( ! skip_y ) {
+			nee_matrix_y_daily = malloc(daily_rows_count*sizeof*nee_matrix_y_daily);
+			if ( !nee_matrix_y_daily ) {
+				puts(err_out_of_memory);
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(percentiles_y);
+				free(p_matrix_y);
+				free(nee_matrix_y);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(p_matrix_c);
+					free(nee_matrix_c);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			nee_matrix_y_daily = NULL;
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			nee_matrix_c_daily = malloc(daily_rows_count*sizeof*nee_matrix_c_daily);
@@ -4954,7 +5077,9 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			}
 		}
 		/* change qc for y and c */
-		change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+		if ( ! skip_y ) {
+			change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			change_qcs(nee_matrix_c, datasets[dataset].rows_count);
 		}
@@ -4963,23 +5088,29 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		index = 0;
 		for ( row = 0; row < datasets[dataset].rows_count; row += rows_per_day ) {
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-				nee_matrix_y_daily[index].nee[percentile] = 0.0;
-				nee_matrix_y_daily[index].qc[percentile] = 0.0;
+				if ( ! skip_y ) {
+					nee_matrix_y_daily[index].nee[percentile] = 0.0;
+					nee_matrix_y_daily[index].qc[percentile] = 0.0;
+				}
 				if ( datasets[dataset].years_count >= 3 ) {
 					nee_matrix_c_daily[index].nee[percentile] = 0.0;
 					nee_matrix_c_daily[index].qc[percentile] = 0.0;
 				}
 				for ( i = 0; i < rows_per_day; i++ ) {
-					nee_matrix_y_daily[index].nee[percentile] += nee_matrix_y[row+i].nee[percentile];
-					nee_matrix_y_daily[index].qc[percentile] += nee_matrix_y[row+i].qc[percentile];
+					if ( ! skip_y ) {
+						nee_matrix_y_daily[index].nee[percentile] += nee_matrix_y[row+i].nee[percentile];
+						nee_matrix_y_daily[index].qc[percentile] += nee_matrix_y[row+i].qc[percentile];
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_daily[index].nee[percentile] += nee_matrix_c[row+i].nee[percentile];
 						nee_matrix_c_daily[index].qc[percentile] += nee_matrix_c[row+i].qc[percentile];
 					}
 				}
-				nee_matrix_y_daily[index].nee[percentile] /= rows_per_day;
-				nee_matrix_y_daily[index].nee[percentile] *= CO2TOC;
-				nee_matrix_y_daily[index].qc[percentile] /= rows_per_day;
+				if ( ! skip_y ) {
+					nee_matrix_y_daily[index].nee[percentile] /= rows_per_day;
+					nee_matrix_y_daily[index].nee[percentile] *= CO2TOC;
+					nee_matrix_y_daily[index].qc[percentile] /= rows_per_day;
+				}
 				if ( datasets[dataset].years_count >= 3 ) {
 					nee_matrix_c_daily[index].nee[percentile] /= rows_per_day;
 					nee_matrix_c_daily[index].nee[percentile] *= CO2TOC;
@@ -5009,27 +5140,29 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		if ( datasets[dataset].years_count >= 3 ) {
 			free(p_matrix_c);
 		}
-		free(p_matrix_y);
+		if ( ! skip_y ) {
+			free(p_matrix_y);
+		}
 		
 		/* update */
 		rows_count = daily_rows_count;
 
-		/* saving y nee dd matrix */
+		/* saving nee dd matrix */
 		if ( percentiles_save ) {
-			if ( ! save_nee_matrix(nee_matrix_y_daily, &datasets[dataset], DD_Y) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				free(percentiles_y);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
+			if ( ! skip_y ) {
+				if ( ! save_nee_matrix(nee_matrix_y_daily, &datasets[dataset], DD_Y) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					free(percentiles_y);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+					}
+					continue;
 				}
-				continue;
 			}
-
-			/* saving c nee dd matrix */
 			if ( datasets[dataset].years_count >= 3 ) {
 				if ( ! save_nee_matrix(nee_matrix_c_daily, &datasets[dataset], DD_C) ) {
 					free(unc_rows_temp);
@@ -5046,20 +5179,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 
 		/* get p_matrix */
-		p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_daily, rows_count, &ref_y, DD_Y);
-		if ( !p_matrix_y ) {
-			puts("unable to get p_matrix for daily y");
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(percentiles_y);
-			free(nee_matrix_y);
-			free(nee_matrix_y_daily);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c);
-				free(nee_matrix_c_daily);
+		if ( ! skip_y ) {
+			p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_daily, rows_count, &ref_y, DD_Y);
+			if ( !p_matrix_y ) {
+				puts("unable to get p_matrix for daily y");
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(percentiles_y);
+				free(nee_matrix_y);
+				free(nee_matrix_y_daily);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c);
+					free(nee_matrix_c_daily);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			p_matrix_y = NULL;
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			p_matrix_c = process_nee_matrix(&datasets[dataset], nee_matrix_c_daily, rows_count, &ref_c, DD_C);
@@ -5081,28 +5218,34 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		/* ref changed ? */
 		if ( (ref_y_old != ref_y) || (ref_c_old != ref_c) ) {
 			/* revert back qcs */
-			revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				revert_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
-			/* compute random again */
-			if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(percentiles_y);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
-					free(nee_matrix_c_daily);
+			if ( ! no_rand_unc ) {
+				/* compute random again */
+				if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(percentiles_y);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* change qcs */
-			change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				change_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
@@ -5128,7 +5271,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* rand unc dd */
 		if ( ! no_rand_unc ) {
-			rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres));
+			rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres), skip_y);
 		}
 
 		/* save output dd */
@@ -5152,22 +5295,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* write header dd */
 		fprintf(f, header_file_dd, TIMESTAMP_STRING);
-		if ( no_rand_unc ) {
-			fputs(output_var_1, f);
-		} else {
-			fputs(output_var_1_rand_unc, f);
-		}
-		for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
-			fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
-			if ( percentile < PERCENTILES_COUNT_1-1 ) {
-				fputs(",", f);
+		if ( ! skip_y ) {
+			if ( no_rand_unc ) {
+				fputs(output_var_1, f);
+			} else {
+				fputs(output_var_1_rand_unc, f);
+			}
+			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {		
+				fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
+				if ( percentile < PERCENTILES_COUNT_1-1 ) {
+					fputs(",", f);
+				}
 			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(output_var_2, f);
+				fputs(output_var_2 + skip_y, f);
 			} else {
-				fputs(output_var_2_rand_unc, f);
+				fputs(output_var_2_rand_unc + skip_y, f);
 			}
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
 				fprintf(f, "NEE_%02g_c,NEE_%02g_qc_c", percentiles_test_1[percentile],percentiles_test_1[percentile]);
@@ -5178,16 +5323,20 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 		if ( no_rand_unc ) {
 			fputs(header_file_night_no_rand_unc, f);
-			fputs(header_file_night_y_no_rand_unc, f);
+			if ( ! skip_y ) {
+				fputs(header_file_night_y_no_rand_unc, f);
+			}
 		} else {
 			fputs(header_file_night, f);
-			fputs(header_file_night_y, f);
+			if ( ! skip_y ) {
+				fputs(header_file_night_y, f);
+			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(header_file_night_c_no_rand_unc, f);
+				fputs(header_file_night_c_no_rand_unc + skip_y, f);
 			} else {
-				fputs(header_file_night_c, f);
+				fputs(header_file_night_c + skip_y, f);
 			}
 		} else {
 			fputs("\n", f);
@@ -5215,67 +5364,68 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													t->DD,
 													row+1			
 				);
-
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-															nee_matrix_y_daily[j+row].nee[ref_y],
-															nee_matrix_y_daily[j+row].qc[ref_y],
-															nee_matrix_y_daily[j+row].nee[PERCENTILES_COUNT_2-1],
-															nee_matrix_y_daily[j+row].qc[PERCENTILES_COUNT_2-1],
-															p_matrix_y[j+row].mean,
-															p_matrix_y[j+row].mean_qc,
-															p_matrix_y[j+row].std_err
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																nee_matrix_y_daily[j+row].nee[ref_y],
+																nee_matrix_y_daily[j+row].qc[ref_y],
+																nee_matrix_y_daily[j+row].nee[PERCENTILES_COUNT_2-1],
+																nee_matrix_y_daily[j+row].qc[PERCENTILES_COUNT_2-1],
+																p_matrix_y[j+row].mean,
+																p_matrix_y[j+row].mean_qc,
+																p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_joinUnc_y = compute_join(unc_rows_aggr[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							nee_ust50_joinUnc_y = compute_join(unc_rows_aggr[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+																			nee_matrix_y_daily[j+row].nee[ref_y],
+																			nee_matrix_y_daily[j+row].qc[ref_y],
+																			unc_rows_aggr[j+row].rand[NEE_REF_Y_UNC],
+																			nee_ref_joinUnc_y,
+																			nee_matrix_y_daily[j+row].nee[PERCENTILES_COUNT_2-1],
+																			nee_matrix_y_daily[j+row].qc[PERCENTILES_COUNT_2-1],
+																			unc_rows_aggr[j+row].rand[NEE_UST50_Y_UNC],
+																			nee_ust50_joinUnc_y,
+																			p_matrix_y[j+row].mean,
+																			p_matrix_y[j+row].mean_qc,
+																			p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE,
+																			(PREC)INVALID_VALUE
+							);
+						}
 					}
-				} else {
-					if ( exists ) {
-						nee_ref_joinUnc_y = compute_join(unc_rows_aggr[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						nee_ust50_joinUnc_y = compute_join(unc_rows_aggr[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-																		nee_matrix_y_daily[j+row].nee[ref_y],
-																		nee_matrix_y_daily[j+row].qc[ref_y],
-																		unc_rows_aggr[j+row].rand[NEE_REF_Y_UNC],
-																		nee_ref_joinUnc_y,
-																		nee_matrix_y_daily[j+row].nee[PERCENTILES_COUNT_2-1],
-																		nee_matrix_y_daily[j+row].qc[PERCENTILES_COUNT_2-1],
-																		unc_rows_aggr[j+row].rand[NEE_UST50_Y_UNC],
-																		nee_ust50_joinUnc_y,
-																		p_matrix_y[j+row].mean,
-																		p_matrix_y[j+row].mean_qc,
-																		p_matrix_y[j+row].std_err
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE,
-																		(PREC)INVALID_VALUE
-						);
-					}
-				}
-				for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
-					} else {
-						fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+					for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
+						} else {
+							fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+						}
 					}
 				}
 
@@ -5372,208 +5522,210 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 						);
 					}
 				}
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-																rows_night_daily[j+row].night[NEE_REF_Y],
-																rows_night_daily[j+row].night_std[NEE_REF_Y],
-																rows_night_daily[j+row].night_qc[NEE_REF_Y],
-																rows_night_daily[j+row].day[NEE_REF_Y],
-																rows_night_daily[j+row].day_std[NEE_REF_Y],
-																rows_night_daily[j+row].day_qc[NEE_REF_Y],
-																rows_night_daily[j+row].night[NEE_UST50_Y],
-																rows_night_daily[j+row].night_std[NEE_UST50_Y],
-																rows_night_daily[j+row].night_qc[NEE_UST50_Y],
-																rows_night_daily[j+row].day[NEE_UST50_Y],
-																rows_night_daily[j+row].day_std[NEE_UST50_Y],
-																rows_night_daily[j+row].day_qc[NEE_UST50_Y],
-																rows_night_daily[j+row].night[NEE_05_Y],
-																rows_night_daily[j+row].night[NEE_05_QC_Y],
-																rows_night_daily[j+row].night[NEE_16_Y],
-																rows_night_daily[j+row].night[NEE_16_QC_Y],
-																rows_night_daily[j+row].night[NEE_25_Y],
-																rows_night_daily[j+row].night[NEE_25_QC_Y],
-																rows_night_daily[j+row].night[NEE_50_Y],
-																rows_night_daily[j+row].night[NEE_50_QC_Y],
-																rows_night_daily[j+row].night[NEE_75_Y],
-																rows_night_daily[j+row].night[NEE_75_QC_Y],
-																rows_night_daily[j+row].night[NEE_84_Y],
-																rows_night_daily[j+row].night[NEE_84_QC_Y],
-																rows_night_daily[j+row].night[NEE_95_Y],
-																rows_night_daily[j+row].night[NEE_95_QC_Y],
-																rows_night_daily[j+row].day[NEE_05_Y],
-																rows_night_daily[j+row].day[NEE_05_QC_Y],
-																rows_night_daily[j+row].day[NEE_16_Y],
-																rows_night_daily[j+row].day[NEE_16_QC_Y],
-																rows_night_daily[j+row].day[NEE_25_Y],
-																rows_night_daily[j+row].day[NEE_25_QC_Y],
-																rows_night_daily[j+row].day[NEE_50_Y],
-																rows_night_daily[j+row].day[NEE_50_QC_Y],
-																rows_night_daily[j+row].day[NEE_75_Y],
-																rows_night_daily[j+row].day[NEE_75_QC_Y],
-																rows_night_daily[j+row].day[NEE_84_Y],
-																rows_night_daily[j+row].day[NEE_84_QC_Y],
-																rows_night_daily[j+row].day[NEE_95_Y],
-																rows_night_daily[j+row].day[NEE_95_QC_Y]
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+																	rows_night_daily[j+row].night[NEE_REF_Y],
+																	rows_night_daily[j+row].night_std[NEE_REF_Y],
+																	rows_night_daily[j+row].night_qc[NEE_REF_Y],
+																	rows_night_daily[j+row].day[NEE_REF_Y],
+																	rows_night_daily[j+row].day_std[NEE_REF_Y],
+																	rows_night_daily[j+row].day_qc[NEE_REF_Y],
+																	rows_night_daily[j+row].night[NEE_UST50_Y],
+																	rows_night_daily[j+row].night_std[NEE_UST50_Y],
+																	rows_night_daily[j+row].night_qc[NEE_UST50_Y],
+																	rows_night_daily[j+row].day[NEE_UST50_Y],
+																	rows_night_daily[j+row].day_std[NEE_UST50_Y],
+																	rows_night_daily[j+row].day_qc[NEE_UST50_Y],
+																	rows_night_daily[j+row].night[NEE_05_Y],
+																	rows_night_daily[j+row].night[NEE_05_QC_Y],
+																	rows_night_daily[j+row].night[NEE_16_Y],
+																	rows_night_daily[j+row].night[NEE_16_QC_Y],
+																	rows_night_daily[j+row].night[NEE_25_Y],
+																	rows_night_daily[j+row].night[NEE_25_QC_Y],
+																	rows_night_daily[j+row].night[NEE_50_Y],
+																	rows_night_daily[j+row].night[NEE_50_QC_Y],
+																	rows_night_daily[j+row].night[NEE_75_Y],
+																	rows_night_daily[j+row].night[NEE_75_QC_Y],
+																	rows_night_daily[j+row].night[NEE_84_Y],
+																	rows_night_daily[j+row].night[NEE_84_QC_Y],
+																	rows_night_daily[j+row].night[NEE_95_Y],
+																	rows_night_daily[j+row].night[NEE_95_QC_Y],
+																	rows_night_daily[j+row].day[NEE_05_Y],
+																	rows_night_daily[j+row].day[NEE_05_QC_Y],
+																	rows_night_daily[j+row].day[NEE_16_Y],
+																	rows_night_daily[j+row].day[NEE_16_QC_Y],
+																	rows_night_daily[j+row].day[NEE_25_Y],
+																	rows_night_daily[j+row].day[NEE_25_QC_Y],
+																	rows_night_daily[j+row].day[NEE_50_Y],
+																	rows_night_daily[j+row].day[NEE_50_QC_Y],
+																	rows_night_daily[j+row].day[NEE_75_Y],
+																	rows_night_daily[j+row].day[NEE_75_QC_Y],
+																	rows_night_daily[j+row].day[NEE_84_Y],
+																	rows_night_daily[j+row].day[NEE_84_QC_Y],
+																	rows_night_daily[j+row].day[NEE_95_Y],
+																	rows_night_daily[j+row].day[NEE_95_QC_Y]
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE,
+																	(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE,
-																(PREC)INVALID_VALUE
-						);
-					}
-				} else {
-					if ( exists ) {
-						nee_ref_night_joinUnc_y = compute_join(rows_night_daily[j+row].night[NEE_REF_Y_RAND],rows_night_daily[j+row].night[NEE_16_Y],rows_night_daily[j+row].night[NEE_84_Y]);
-						nee_ref_day_joinUnc_y = compute_join(rows_night_daily[j+row].day[NEE_REF_Y_RAND],rows_night_daily[j+row].day[NEE_16_Y],rows_night_daily[j+row].day[NEE_84_Y]);
-						nee_ust50_night_joinUnc_y = compute_join(rows_night_daily[j+row].night[NEE_UST50_Y_RAND],rows_night_daily[j+row].night[NEE_16_Y],rows_night_daily[j+row].night[NEE_84_Y]);
-						nee_ust50_day_joinUnc_y = compute_join(rows_night_daily[j+row].day[NEE_UST50_Y_RAND],rows_night_daily[j+row].day[NEE_16_Y],rows_night_daily[j+row].day[NEE_84_Y]);
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														rows_night_daily[j+row].night[NEE_REF_Y],
-														rows_night_daily[j+row].night_std[NEE_REF_Y],
-														rows_night_daily[j+row].night_qc[NEE_REF_Y],
-														rows_night_daily[j+row].night[NEE_REF_Y_RAND],
-														nee_ref_night_joinUnc_y,
-														rows_night_daily[j+row].day[NEE_REF_Y],
-														rows_night_daily[j+row].day_std[NEE_REF_Y],
-														rows_night_daily[j+row].day_qc[NEE_REF_Y],
-														rows_night_daily[j+row].day[NEE_REF_Y_RAND],
-														nee_ref_day_joinUnc_y,
-														rows_night_daily[j+row].night[NEE_UST50_Y],
-														rows_night_daily[j+row].night_std[NEE_UST50_Y],
-														rows_night_daily[j+row].night_qc[NEE_UST50_Y],
-														rows_night_daily[j+row].night[NEE_UST50_Y_RAND],
-														nee_ust50_night_joinUnc_y,
-														rows_night_daily[j+row].day[NEE_UST50_Y],
-														rows_night_daily[j+row].day_std[NEE_UST50_Y],
-														rows_night_daily[j+row].day_qc[NEE_UST50_Y],
-														rows_night_daily[j+row].day[NEE_UST50_Y_RAND],
-														nee_ust50_day_joinUnc_y,
-														rows_night_daily[j+row].night[NEE_05_Y],
-														rows_night_daily[j+row].night[NEE_05_QC_Y],
-														rows_night_daily[j+row].night[NEE_16_Y],
-														rows_night_daily[j+row].night[NEE_16_QC_Y],
-														rows_night_daily[j+row].night[NEE_25_Y],
-														rows_night_daily[j+row].night[NEE_25_QC_Y],
-														rows_night_daily[j+row].night[NEE_50_Y],
-														rows_night_daily[j+row].night[NEE_50_QC_Y],
-														rows_night_daily[j+row].night[NEE_75_Y],
-														rows_night_daily[j+row].night[NEE_75_QC_Y],
-														rows_night_daily[j+row].night[NEE_84_Y],
-														rows_night_daily[j+row].night[NEE_84_QC_Y],
-														rows_night_daily[j+row].night[NEE_95_Y],
-														rows_night_daily[j+row].night[NEE_95_QC_Y],
-														rows_night_daily[j+row].day[NEE_05_Y],
-														rows_night_daily[j+row].day[NEE_05_QC_Y],
-														rows_night_daily[j+row].day[NEE_16_Y],
-														rows_night_daily[j+row].day[NEE_16_QC_Y],
-														rows_night_daily[j+row].day[NEE_25_Y],
-														rows_night_daily[j+row].day[NEE_25_QC_Y],
-														rows_night_daily[j+row].day[NEE_50_Y],
-														rows_night_daily[j+row].day[NEE_50_QC_Y],
-														rows_night_daily[j+row].day[NEE_75_Y],
-														rows_night_daily[j+row].day[NEE_75_QC_Y],
-														rows_night_daily[j+row].day[NEE_84_Y],
-														rows_night_daily[j+row].day[NEE_84_QC_Y],
-														rows_night_daily[j+row].day[NEE_95_Y],
-														rows_night_daily[j+row].day[NEE_95_QC_Y]
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_night_joinUnc_y = compute_join(rows_night_daily[j+row].night[NEE_REF_Y_RAND],rows_night_daily[j+row].night[NEE_16_Y],rows_night_daily[j+row].night[NEE_84_Y]);
+							nee_ref_day_joinUnc_y = compute_join(rows_night_daily[j+row].day[NEE_REF_Y_RAND],rows_night_daily[j+row].day[NEE_16_Y],rows_night_daily[j+row].day[NEE_84_Y]);
+							nee_ust50_night_joinUnc_y = compute_join(rows_night_daily[j+row].night[NEE_UST50_Y_RAND],rows_night_daily[j+row].night[NEE_16_Y],rows_night_daily[j+row].night[NEE_84_Y]);
+							nee_ust50_day_joinUnc_y = compute_join(rows_night_daily[j+row].day[NEE_UST50_Y_RAND],rows_night_daily[j+row].day[NEE_16_Y],rows_night_daily[j+row].day[NEE_84_Y]);
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															rows_night_daily[j+row].night[NEE_REF_Y],
+															rows_night_daily[j+row].night_std[NEE_REF_Y],
+															rows_night_daily[j+row].night_qc[NEE_REF_Y],
+															rows_night_daily[j+row].night[NEE_REF_Y_RAND],
+															nee_ref_night_joinUnc_y,
+															rows_night_daily[j+row].day[NEE_REF_Y],
+															rows_night_daily[j+row].day_std[NEE_REF_Y],
+															rows_night_daily[j+row].day_qc[NEE_REF_Y],
+															rows_night_daily[j+row].day[NEE_REF_Y_RAND],
+															nee_ref_day_joinUnc_y,
+															rows_night_daily[j+row].night[NEE_UST50_Y],
+															rows_night_daily[j+row].night_std[NEE_UST50_Y],
+															rows_night_daily[j+row].night_qc[NEE_UST50_Y],
+															rows_night_daily[j+row].night[NEE_UST50_Y_RAND],
+															nee_ust50_night_joinUnc_y,
+															rows_night_daily[j+row].day[NEE_UST50_Y],
+															rows_night_daily[j+row].day_std[NEE_UST50_Y],
+															rows_night_daily[j+row].day_qc[NEE_UST50_Y],
+															rows_night_daily[j+row].day[NEE_UST50_Y_RAND],
+															nee_ust50_day_joinUnc_y,
+															rows_night_daily[j+row].night[NEE_05_Y],
+															rows_night_daily[j+row].night[NEE_05_QC_Y],
+															rows_night_daily[j+row].night[NEE_16_Y],
+															rows_night_daily[j+row].night[NEE_16_QC_Y],
+															rows_night_daily[j+row].night[NEE_25_Y],
+															rows_night_daily[j+row].night[NEE_25_QC_Y],
+															rows_night_daily[j+row].night[NEE_50_Y],
+															rows_night_daily[j+row].night[NEE_50_QC_Y],
+															rows_night_daily[j+row].night[NEE_75_Y],
+															rows_night_daily[j+row].night[NEE_75_QC_Y],
+															rows_night_daily[j+row].night[NEE_84_Y],
+															rows_night_daily[j+row].night[NEE_84_QC_Y],
+															rows_night_daily[j+row].night[NEE_95_Y],
+															rows_night_daily[j+row].night[NEE_95_QC_Y],
+															rows_night_daily[j+row].day[NEE_05_Y],
+															rows_night_daily[j+row].day[NEE_05_QC_Y],
+															rows_night_daily[j+row].day[NEE_16_Y],
+															rows_night_daily[j+row].day[NEE_16_QC_Y],
+															rows_night_daily[j+row].day[NEE_25_Y],
+															rows_night_daily[j+row].day[NEE_25_QC_Y],
+															rows_night_daily[j+row].day[NEE_50_Y],
+															rows_night_daily[j+row].day[NEE_50_QC_Y],
+															rows_night_daily[j+row].day[NEE_75_Y],
+															rows_night_daily[j+row].day[NEE_75_QC_Y],
+															rows_night_daily[j+row].day[NEE_84_Y],
+															rows_night_daily[j+row].day[NEE_84_QC_Y],
+															rows_night_daily[j+row].day[NEE_95_Y],
+															rows_night_daily[j+row].day[NEE_95_QC_Y]
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE
+							);
+						}
 					}
 				}
-
 				if ( datasets[dataset].years_count >= 3 ) {
 					if ( no_rand_unc ) {
 						if ( exists ) {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														rows_night_daily[j+row].night[NEE_REF_C],
 														rows_night_daily[j+row].night_std[NEE_REF_C],
 														rows_night_daily[j+row].night_qc[NEE_REF_C],
@@ -5616,7 +5768,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 														rows_night_daily[j+row].day[NEE_95_QC_C]
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
@@ -5665,7 +5818,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 							nee_ref_day_joinUnc_c = compute_join(rows_night_daily[j+row].day[NEE_REF_C_RAND],rows_night_daily[j+row].day[NEE_16_C],rows_night_daily[j+row].day[NEE_84_C]);
 							nee_ust50_night_joinUnc_c = compute_join(rows_night_daily[j+row].night[NEE_UST50_C_RAND],rows_night_daily[j+row].night[NEE_16_C],rows_night_daily[j+row].night[NEE_84_C]);
 							nee_ust50_day_joinUnc_c = compute_join(rows_night_daily[j+row].day[NEE_UST50_C_RAND],rows_night_daily[j+row].day[NEE_16_C],rows_night_daily[j+row].day[NEE_84_C]);
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														rows_night_daily[j+row].night[NEE_REF_C],
 														rows_night_daily[j+row].night_std[NEE_REF_C],
 														rows_night_daily[j+row].night_qc[NEE_REF_C],
@@ -5716,7 +5870,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 														rows_night_daily[j+row].day[NEE_95_QC_C]
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
@@ -5788,7 +5943,9 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		fclose(f);
 
 		/* free memory */
-		free(p_matrix_y);
+		if ( ! skip_y ) {
+			free(p_matrix_y);
+		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			free(p_matrix_c);
 		}
@@ -5818,19 +5975,23 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		printf("computing ww...");
 
 		weekly_rows_count = 52 * datasets[dataset].years_count;
-		nee_matrix_y_weekly = malloc(weekly_rows_count*sizeof*nee_matrix_y_weekly);
-		if ( !nee_matrix_y_weekly ) {
-			puts(err_out_of_memory);
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(rows_night_daily);
-			free(percentiles_y);		
-			free(nee_matrix_y_daily);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c_daily);
+		if ( ! skip_y ) {
+			nee_matrix_y_weekly = malloc(weekly_rows_count*sizeof*nee_matrix_y_weekly);
+			if ( !nee_matrix_y_weekly ) {
+				puts(err_out_of_memory);
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(rows_night_daily);
+				free(percentiles_y);		
+				free(nee_matrix_y_daily);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c_daily);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			nee_matrix_y_weekly = NULL;
 		}
 
 		if ( datasets[dataset].years_count >= 3 ) {		
@@ -5885,22 +6046,28 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			for ( i = 0; i < 51; i++ ) {
 				row = i*7;
 				for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-					nee_matrix_y_weekly[index+i].nee[percentile] = 0.0;
-					nee_matrix_y_weekly[index+i].qc[percentile] = 0.0;
+					if ( ! skip_y ) {
+						nee_matrix_y_weekly[index+i].nee[percentile] = 0.0;
+						nee_matrix_y_weekly[index+i].qc[percentile] = 0.0;
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_weekly[index+i].nee[percentile] = 0.0;
 						nee_matrix_c_weekly[index+i].qc[percentile] = 0.0;
 					}
 					for ( j = 0; j < 7; j++ ) {
-						nee_matrix_y_weekly[index+i].nee[percentile] += nee_matrix_y_daily[element+row+j].nee[percentile];
-						nee_matrix_y_weekly[index+i].qc[percentile] += nee_matrix_y_daily[element+row+j].qc[percentile];
+						if ( ! skip_y ) {
+							nee_matrix_y_weekly[index+i].nee[percentile] += nee_matrix_y_daily[element+row+j].nee[percentile];
+							nee_matrix_y_weekly[index+i].qc[percentile] += nee_matrix_y_daily[element+row+j].qc[percentile];
+						}
 						if ( datasets[dataset].years_count >= 3 ) {
 							nee_matrix_c_weekly[index+i].nee[percentile] += nee_matrix_c_daily[element+row+j].nee[percentile];
 							nee_matrix_c_weekly[index+i].qc[percentile] += nee_matrix_c_daily[element+row+j].qc[percentile];
 						}
 					}
-					nee_matrix_y_weekly[index+i].nee[percentile] /= 7;
-					nee_matrix_y_weekly[index+i].qc[percentile] /= 7;
+					if ( ! skip_y ) {
+						nee_matrix_y_weekly[index+i].nee[percentile] /= 7;
+						nee_matrix_y_weekly[index+i].qc[percentile] /= 7;
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_weekly[index+i].nee[percentile] /= 7;
 						nee_matrix_c_weekly[index+i].qc[percentile] /= 7;
@@ -5910,22 +6077,28 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			row += j; /* 51*7 */; 
 			z = y-row;
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-				nee_matrix_y_weekly[index+i].nee[percentile] = 0.0;
-				nee_matrix_y_weekly[index+i].qc[percentile] = 0.0;
+				if ( ! skip_y ) {
+					nee_matrix_y_weekly[index+i].nee[percentile] = 0.0;
+					nee_matrix_y_weekly[index+i].qc[percentile] = 0.0;
+				}
 				if ( datasets[dataset].years_count >= 3 ) {
 					nee_matrix_c_weekly[index+i].nee[percentile] = 0.0;
 					nee_matrix_c_weekly[index+i].qc[percentile] = 0.0;
 				}
 				for ( j = 0; j < z; j++ ) {
-					nee_matrix_y_weekly[index+i].nee[percentile] += nee_matrix_y_daily[element+row+j].nee[percentile];
-					nee_matrix_y_weekly[index+i].qc[percentile] += nee_matrix_y_daily[element+row+j].qc[percentile];
+					if ( ! skip_y ) {
+						nee_matrix_y_weekly[index+i].nee[percentile] += nee_matrix_y_daily[element+row+j].nee[percentile];
+						nee_matrix_y_weekly[index+i].qc[percentile] += nee_matrix_y_daily[element+row+j].qc[percentile];
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_weekly[index+i].nee[percentile] += nee_matrix_c_daily[element+row+j].nee[percentile];
 						nee_matrix_c_weekly[index+i].qc[percentile] += nee_matrix_c_daily[element+row+j].qc[percentile];
 					}
 				}
-				nee_matrix_y_weekly[index+i].nee[percentile] /= z;
-				nee_matrix_y_weekly[index+i].qc[percentile] /= z;
+				if ( ! skip_y ) {
+					nee_matrix_y_weekly[index+i].nee[percentile] /= z;
+					nee_matrix_y_weekly[index+i].qc[percentile] /= z;
+				}
 				if ( datasets[dataset].years_count >= 3 ) {
 					nee_matrix_c_weekly[index+i].nee[percentile] /= z;
 					nee_matrix_c_weekly[index+i].qc[percentile] /= z;
@@ -5939,20 +6112,22 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* saving y nee ww matrix */
 		if ( percentiles_save ) {
-			if ( ! save_nee_matrix(nee_matrix_y_weekly, &datasets[dataset], WW_Y) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(rows_night_weekly);
-				free(rows_night_daily);
-				free(percentiles_y);
-				free(nee_matrix_y_weekly);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c_weekly);
-					free(nee_matrix_c_daily);
+			if ( ! skip_y ) {
+				if ( ! save_nee_matrix(nee_matrix_y_weekly, &datasets[dataset], WW_Y) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(rows_night_weekly);
+					free(rows_night_daily);
+					free(percentiles_y);
+					free(nee_matrix_y_weekly);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c_weekly);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* saving c nee ww matrix */
@@ -5974,22 +6149,26 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 
 		/* get p_matrix */
-		p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_weekly, weekly_rows_count, &ref_y, WW_Y);
-		if ( !p_matrix_y ) {
-			puts("unable to get p_matrix for weekly y");
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(rows_night_weekly);
-			free(rows_night_daily);
-			free(percentiles_y);
-			free(nee_matrix_y_weekly);
-			free(nee_matrix_y_daily);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c_weekly);
-				free(nee_matrix_c_daily);
+		if ( ! skip_y ) {
+			p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_weekly, weekly_rows_count, &ref_y, WW_Y);
+			if ( !p_matrix_y ) {
+				puts("unable to get p_matrix for weekly y");
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(rows_night_weekly);
+				free(rows_night_daily);
+				free(percentiles_y);
+				free(nee_matrix_y_weekly);
+				free(nee_matrix_y_daily);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c_weekly);
+					free(nee_matrix_c_daily);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			p_matrix_y = NULL;
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			p_matrix_c = process_nee_matrix(&datasets[dataset], nee_matrix_c_weekly, weekly_rows_count, &ref_c, WW_C);
@@ -6191,46 +6370,54 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		/* ref changed ? */
 		if ( (ref_y_old != ref_y) || (ref_c_old != ref_c) ) {
 			/* revert back qcs */
-			revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				revert_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
 			/* compute random again */
-			if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(percentiles_y);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
-					free(nee_matrix_c_daily);
+			if ( ! no_rand_unc ) {
+				if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(percentiles_y);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* change qcs */
-			change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				change_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
-			if ( ! compute_night_rand(&datasets[dataset], rows_night_daily, unc_rows) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(percentiles_y);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
-					free(nee_matrix_c_daily);
+			if ( ! no_rand_unc ) {
+				if ( ! compute_night_rand(&datasets[dataset], rows_night_daily, unc_rows, skip_y) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(percentiles_y);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
+				rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres), skip_y);
 			}
-			rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres));
 			ref_y_old = ref_y;
 			ref_c_old = ref_c;
 		}
@@ -6259,6 +6446,16 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				rows_night_weekly[index+i].night_total /= 7;
 				rows_night_weekly[index+i].day_total /= 7;
 				for ( percentile = 0; percentile < NIGHT_VALUES; percentile++ ) {
+					/* do not compute _y if it was skipped */
+					if ( skip_y &&
+							((NEE_REF_Y == percentile) || (NEE_UST50_Y == percentile) || (NEE_REF_Y_RAND == percentile) || (NEE_UST50_Y_RAND == percentile) ||
+							(NEE_05_Y == percentile) || (NEE_05_QC_Y == percentile) || (NEE_16_Y == percentile) || (NEE_16_QC_Y == percentile) ||
+							(NEE_25_Y == percentile) || (NEE_25_QC_Y == percentile) || (NEE_50_Y == percentile) || (NEE_50_QC_Y == percentile) ||
+							(NEE_75_Y == percentile) || (NEE_75_QC_Y == percentile) ||
+							(NEE_84_Y == percentile) || (NEE_84_QC_Y == percentile) || (NEE_95_Y == percentile) || (NEE_95_QC_Y == percentile))
+							) {
+						continue;
+					}
 					/* do not compute _c if years count is less than 3 */
 					if ( (datasets[dataset].years_count < 3) &&
 							((NEE_REF_C == percentile) || (NEE_UST50_C == percentile) || (NEE_REF_C_RAND == percentile) || (NEE_UST50_C_RAND == percentile) ||
@@ -6384,6 +6581,16 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			rows_night_weekly[index+i].night_total /= z;
 			rows_night_weekly[index+i].day_total /= z;
 			for ( percentile = 0; percentile < NIGHT_VALUES; percentile++ ) {
+				/* do not compute _y if it was skipped */
+				if ( skip_y &&
+						((NEE_REF_Y == percentile) || (NEE_UST50_Y == percentile) || (NEE_REF_Y_RAND == percentile) || (NEE_UST50_Y_RAND == percentile) ||
+						(NEE_05_Y == percentile) || (NEE_05_QC_Y == percentile) || (NEE_16_Y == percentile) || (NEE_16_QC_Y == percentile) ||
+						(NEE_25_Y == percentile) || (NEE_25_QC_Y == percentile) || (NEE_50_Y == percentile) || (NEE_50_QC_Y == percentile) ||
+						(NEE_75_Y == percentile) || (NEE_75_QC_Y == percentile) ||
+						(NEE_84_Y == percentile) || (NEE_84_QC_Y == percentile) || (NEE_95_Y == percentile) || (NEE_95_QC_Y == percentile))
+						) {
+					continue;
+				}
 				/* do not compute _c if years count is less than 3 */
 				if ( (datasets[dataset].years_count < 3) &&
 						((NEE_REF_C == percentile) || (NEE_UST50_C == percentile) || (NEE_REF_C_RAND == percentile) || (NEE_UST50_C_RAND == percentile) ||
@@ -6502,7 +6709,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 		
 		/* update percentile and qc*/
-		if ( ! update_ww(&datasets[dataset], rows_night_daily, daily_rows_count, rows_night_weekly, weekly_rows_count) ) {
+		if ( ! update_ww(&datasets[dataset], rows_night_daily, daily_rows_count, rows_night_weekly, weekly_rows_count, skip_y) ) {
 			free(unc_rows_temp);
 			free(unc_rows_aggr);
 			free(unc_rows);
@@ -6673,7 +6880,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* rand unc ww */
 		if ( ! no_rand_unc ) {
-			rand_unc_ww(unc_rows_aggr, unc_rows_temp, datasets[dataset].rows_count / rows_per_day, datasets[dataset].years[0].year, datasets[dataset].years_count);
+			rand_unc_ww(unc_rows_aggr, unc_rows_temp, datasets[dataset].rows_count / rows_per_day, datasets[dataset].years[0].year, datasets[dataset].years_count, skip_y);
 		}
 
 		printf("ok\nsaving ww...");
@@ -6701,22 +6908,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* write header ww */
 		fprintf(f, header_file_ww, TIMESTAMP_HEADER);
-		if ( no_rand_unc ) {
-			fputs(output_var_1, f);
-		} else {
-			fputs(output_var_1_rand_unc, f);
-		}
-		for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
-			fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
-			if ( percentile < PERCENTILES_COUNT_1-1 ) {
-				fputs(",", f);
+		if ( ! skip_y ) {
+			if ( no_rand_unc ) {
+				fputs(output_var_1, f);
+			} else {
+				fputs(output_var_1_rand_unc, f);
+			}
+			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
+				fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
+				if ( percentile < PERCENTILES_COUNT_1-1 ) {
+					fputs(",", f);
+				}
 			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(output_var_2, f);
+				fputs(output_var_2 + skip_y, f);
 			} else {
-				fputs(output_var_2_rand_unc, f);
+				fputs(output_var_2_rand_unc + skip_y, f);
 			}
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
 				fprintf(f, "NEE_%02g_c,NEE_%02g_qc_c", percentiles_test_1[percentile],percentiles_test_1[percentile]);
@@ -6727,16 +6936,20 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 		if ( no_rand_unc ) {
 			fputs(header_file_night_no_rand_unc, f);
-			fputs(header_file_night_y_no_rand_unc, f);
+			if ( ! skip_y ) {
+				fputs(header_file_night_y_no_rand_unc, f);
+			}
 		} else {
 			fputs(header_file_night, f);
-			fputs(header_file_night_y, f);
+			if ( ! skip_y ) {
+				fputs(header_file_night_y, f);
+			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(header_file_night_c_no_rand_unc, f);
+				fputs(header_file_night_c_no_rand_unc + skip_y, f);
 			} else {
-				fputs(header_file_night_c, f);
+				fputs(header_file_night_c + skip_y, f);
 			}
 		} else {
 			fputs("\n", f);
@@ -6753,66 +6966,68 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				fprintf(f, "%s,", timestamp_ww_get_by_row_s(row, datasets[dataset].years[i].year, datasets[dataset].details->timeres, 0));
 				/* week */
 				fprintf(f, "%d,", row+1);
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-															nee_matrix_y_weekly[j+row].nee[ref_y],
-															nee_matrix_y_weekly[j+row].qc[ref_y],
-															nee_matrix_y_weekly[j+row].nee[PERCENTILES_COUNT_2-1],
-															nee_matrix_y_weekly[j+row].qc[PERCENTILES_COUNT_2-1],
-															p_matrix_y[j+row].mean,
-															p_matrix_y[j+row].mean_qc,
-															p_matrix_y[j+row].std_err
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																nee_matrix_y_weekly[j+row].nee[ref_y],
+																nee_matrix_y_weekly[j+row].qc[ref_y],
+																nee_matrix_y_weekly[j+row].nee[PERCENTILES_COUNT_2-1],
+																nee_matrix_y_weekly[j+row].qc[PERCENTILES_COUNT_2-1],
+																p_matrix_y[j+row].mean,
+																p_matrix_y[j+row].mean_qc,
+																p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							nee_ust50_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+																nee_matrix_y_weekly[j+row].nee[ref_y],
+																nee_matrix_y_weekly[j+row].qc[ref_y],
+																unc_rows_temp[j+row].rand[NEE_REF_Y_UNC],
+																nee_ref_joinUnc_y,
+																nee_matrix_y_weekly[j+row].nee[PERCENTILES_COUNT_2-1],
+																nee_matrix_y_weekly[j+row].qc[PERCENTILES_COUNT_2-1],
+																unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC],
+																nee_ust50_joinUnc_y,
+																p_matrix_y[j+row].mean,
+																p_matrix_y[j+row].mean_qc,
+																p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE
+							);
+						}
 					}
-				} else {
-					if ( exists ) {
-						nee_ref_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						nee_ust50_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-															nee_matrix_y_weekly[j+row].nee[ref_y],
-															nee_matrix_y_weekly[j+row].qc[ref_y],
-															unc_rows_temp[j+row].rand[NEE_REF_Y_UNC],
-															nee_ref_joinUnc_y,
-															nee_matrix_y_weekly[j+row].nee[PERCENTILES_COUNT_2-1],
-															nee_matrix_y_weekly[j+row].qc[PERCENTILES_COUNT_2-1],
-															unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC],
-															nee_ust50_joinUnc_y,
-															p_matrix_y[j+row].mean,
-															p_matrix_y[j+row].mean_qc,
-															p_matrix_y[j+row].std_err
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE
-						);
-					}
-				}
-				for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
-					} else {
-						fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+					for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
+						} else {
+							fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+						}
 					}
 				}
 
@@ -6909,208 +7124,211 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 						);
 					}
 				}
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														rows_night_weekly[j+row].night[NEE_REF_Y],
-														rows_night_weekly[j+row].night_std[NEE_REF_Y],
-														rows_night_weekly[j+row].night_qc[NEE_REF_Y],
-														rows_night_weekly[j+row].day[NEE_REF_Y],
-														rows_night_weekly[j+row].day_std[NEE_REF_Y],
-														rows_night_weekly[j+row].day_qc[NEE_REF_Y],
-														rows_night_weekly[j+row].night[NEE_UST50_Y],
-														rows_night_weekly[j+row].night_std[NEE_UST50_Y],
-														rows_night_weekly[j+row].night_qc[NEE_UST50_Y],
-														rows_night_weekly[j+row].day[NEE_UST50_Y],
-														rows_night_weekly[j+row].day_std[NEE_UST50_Y],
-														rows_night_weekly[j+row].day_qc[NEE_UST50_Y],
-														rows_night_weekly[j+row].night[NEE_05_Y],
-														rows_night_weekly[j+row].night[NEE_05_QC_Y],
-														rows_night_weekly[j+row].night[NEE_16_Y],
-														rows_night_weekly[j+row].night[NEE_16_QC_Y],
-														rows_night_weekly[j+row].night[NEE_25_Y],
-														rows_night_weekly[j+row].night[NEE_25_QC_Y],
-														rows_night_weekly[j+row].night[NEE_50_Y],
-														rows_night_weekly[j+row].night[NEE_50_QC_Y],
-														rows_night_weekly[j+row].night[NEE_75_Y],
-														rows_night_weekly[j+row].night[NEE_75_QC_Y],
-														rows_night_weekly[j+row].night[NEE_84_Y],
-														rows_night_weekly[j+row].night[NEE_84_QC_Y],
-														rows_night_weekly[j+row].night[NEE_95_Y],
-														rows_night_weekly[j+row].night[NEE_95_QC_Y],
-														rows_night_weekly[j+row].day[NEE_05_Y],
-														rows_night_weekly[j+row].day[NEE_05_QC_Y],
-														rows_night_weekly[j+row].day[NEE_16_Y],
-														rows_night_weekly[j+row].day[NEE_16_QC_Y],
-														rows_night_weekly[j+row].day[NEE_25_Y],
-														rows_night_weekly[j+row].day[NEE_25_QC_Y],
-														rows_night_weekly[j+row].day[NEE_50_Y],
-														rows_night_weekly[j+row].day[NEE_50_QC_Y],
-														rows_night_weekly[j+row].day[NEE_75_Y],
-														rows_night_weekly[j+row].day[NEE_75_QC_Y],
-														rows_night_weekly[j+row].day[NEE_84_Y],
-														rows_night_weekly[j+row].day[NEE_84_QC_Y],
-														rows_night_weekly[j+row].day[NEE_95_Y],
-														rows_night_weekly[j+row].day[NEE_95_QC_Y]
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															rows_night_weekly[j+row].night[NEE_REF_Y],
+															rows_night_weekly[j+row].night_std[NEE_REF_Y],
+															rows_night_weekly[j+row].night_qc[NEE_REF_Y],
+															rows_night_weekly[j+row].day[NEE_REF_Y],
+															rows_night_weekly[j+row].day_std[NEE_REF_Y],
+															rows_night_weekly[j+row].day_qc[NEE_REF_Y],
+															rows_night_weekly[j+row].night[NEE_UST50_Y],
+															rows_night_weekly[j+row].night_std[NEE_UST50_Y],
+															rows_night_weekly[j+row].night_qc[NEE_UST50_Y],
+															rows_night_weekly[j+row].day[NEE_UST50_Y],
+															rows_night_weekly[j+row].day_std[NEE_UST50_Y],
+															rows_night_weekly[j+row].day_qc[NEE_UST50_Y],
+															rows_night_weekly[j+row].night[NEE_05_Y],
+															rows_night_weekly[j+row].night[NEE_05_QC_Y],
+															rows_night_weekly[j+row].night[NEE_16_Y],
+															rows_night_weekly[j+row].night[NEE_16_QC_Y],
+															rows_night_weekly[j+row].night[NEE_25_Y],
+															rows_night_weekly[j+row].night[NEE_25_QC_Y],
+															rows_night_weekly[j+row].night[NEE_50_Y],
+															rows_night_weekly[j+row].night[NEE_50_QC_Y],
+															rows_night_weekly[j+row].night[NEE_75_Y],
+															rows_night_weekly[j+row].night[NEE_75_QC_Y],
+															rows_night_weekly[j+row].night[NEE_84_Y],
+															rows_night_weekly[j+row].night[NEE_84_QC_Y],
+															rows_night_weekly[j+row].night[NEE_95_Y],
+															rows_night_weekly[j+row].night[NEE_95_QC_Y],
+															rows_night_weekly[j+row].day[NEE_05_Y],
+															rows_night_weekly[j+row].day[NEE_05_QC_Y],
+															rows_night_weekly[j+row].day[NEE_16_Y],
+															rows_night_weekly[j+row].day[NEE_16_QC_Y],
+															rows_night_weekly[j+row].day[NEE_25_Y],
+															rows_night_weekly[j+row].day[NEE_25_QC_Y],
+															rows_night_weekly[j+row].day[NEE_50_Y],
+															rows_night_weekly[j+row].day[NEE_50_QC_Y],
+															rows_night_weekly[j+row].day[NEE_75_Y],
+															rows_night_weekly[j+row].day[NEE_75_QC_Y],
+															rows_night_weekly[j+row].day[NEE_84_Y],
+															rows_night_weekly[j+row].day[NEE_84_QC_Y],
+															rows_night_weekly[j+row].day[NEE_95_Y],
+															rows_night_weekly[j+row].day[NEE_95_QC_Y]
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE
-						);
-					}
-				} else {
-					if ( exists ) {
-						nee_ref_night_joinUnc_y = compute_join(rows_night_weekly[j+row].night[NEE_REF_Y_RAND],rows_night_weekly[j+row].night[NEE_16_Y],rows_night_weekly[j+row].night[NEE_84_Y]);
-						nee_ref_day_joinUnc_y = compute_join(rows_night_weekly[j+row].day[NEE_REF_Y_RAND],rows_night_weekly[j+row].day[NEE_16_Y],rows_night_weekly[j+row].day[NEE_84_Y]);
-						nee_ust50_night_joinUnc_y = compute_join(rows_night_weekly[j+row].night[NEE_UST50_Y_RAND],rows_night_weekly[j+row].night[NEE_16_Y],rows_night_weekly[j+row].night[NEE_84_Y]);
-						nee_ust50_day_joinUnc_y = compute_join(rows_night_weekly[j+row].day[NEE_UST50_Y_RAND],rows_night_weekly[j+row].day[NEE_16_Y],rows_night_weekly[j+row].day[NEE_84_Y]);
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														rows_night_weekly[j+row].night[NEE_REF_Y],
-														rows_night_weekly[j+row].night_std[NEE_REF_Y],
-														rows_night_weekly[j+row].night_qc[NEE_REF_Y],
-														rows_night_weekly[j+row].night[NEE_REF_Y_RAND],
-														nee_ref_night_joinUnc_y,
-														rows_night_weekly[j+row].day[NEE_REF_Y],
-														rows_night_weekly[j+row].day_std[NEE_REF_Y],
-														rows_night_weekly[j+row].day_qc[NEE_REF_Y],
-														rows_night_weekly[j+row].day[NEE_REF_Y_RAND],
-														nee_ref_day_joinUnc_y,
-														rows_night_weekly[j+row].night[NEE_UST50_Y],
-														rows_night_weekly[j+row].night_std[NEE_UST50_Y],
-														rows_night_weekly[j+row].night_qc[NEE_UST50_Y],
-														rows_night_weekly[j+row].night[NEE_UST50_Y_RAND],
-														nee_ust50_night_joinUnc_y,
-														rows_night_weekly[j+row].day[NEE_UST50_Y],
-														rows_night_weekly[j+row].day_std[NEE_UST50_Y],
-														rows_night_weekly[j+row].day_qc[NEE_UST50_Y],
-														rows_night_weekly[j+row].day[NEE_UST50_Y_RAND],
-														nee_ust50_day_joinUnc_y,
-														rows_night_weekly[j+row].night[NEE_05_Y],
-														rows_night_weekly[j+row].night[NEE_05_QC_Y],
-														rows_night_weekly[j+row].night[NEE_16_Y],
-														rows_night_weekly[j+row].night[NEE_16_QC_Y],
-														rows_night_weekly[j+row].night[NEE_25_Y],
-														rows_night_weekly[j+row].night[NEE_25_QC_Y],
-														rows_night_weekly[j+row].night[NEE_50_Y],
-														rows_night_weekly[j+row].night[NEE_50_QC_Y],
-														rows_night_weekly[j+row].night[NEE_75_Y],
-														rows_night_weekly[j+row].night[NEE_75_QC_Y],
-														rows_night_weekly[j+row].night[NEE_84_Y],
-														rows_night_weekly[j+row].night[NEE_84_QC_Y],
-														rows_night_weekly[j+row].night[NEE_95_Y],
-														rows_night_weekly[j+row].night[NEE_95_QC_Y],
-														rows_night_weekly[j+row].day[NEE_05_Y],
-														rows_night_weekly[j+row].day[NEE_05_QC_Y],
-														rows_night_weekly[j+row].day[NEE_16_Y],
-														rows_night_weekly[j+row].day[NEE_16_QC_Y],
-														rows_night_weekly[j+row].day[NEE_25_Y],
-														rows_night_weekly[j+row].day[NEE_25_QC_Y],
-														rows_night_weekly[j+row].day[NEE_50_Y],
-														rows_night_weekly[j+row].day[NEE_50_QC_Y],
-														rows_night_weekly[j+row].day[NEE_75_Y],
-														rows_night_weekly[j+row].day[NEE_75_QC_Y],
-														rows_night_weekly[j+row].day[NEE_84_Y],
-														rows_night_weekly[j+row].day[NEE_84_QC_Y],
-														rows_night_weekly[j+row].day[NEE_95_Y],
-														rows_night_weekly[j+row].day[NEE_95_QC_Y]
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_night_joinUnc_y = compute_join(rows_night_weekly[j+row].night[NEE_REF_Y_RAND],rows_night_weekly[j+row].night[NEE_16_Y],rows_night_weekly[j+row].night[NEE_84_Y]);
+							nee_ref_day_joinUnc_y = compute_join(rows_night_weekly[j+row].day[NEE_REF_Y_RAND],rows_night_weekly[j+row].day[NEE_16_Y],rows_night_weekly[j+row].day[NEE_84_Y]);
+							nee_ust50_night_joinUnc_y = compute_join(rows_night_weekly[j+row].night[NEE_UST50_Y_RAND],rows_night_weekly[j+row].night[NEE_16_Y],rows_night_weekly[j+row].night[NEE_84_Y]);
+							nee_ust50_day_joinUnc_y = compute_join(rows_night_weekly[j+row].day[NEE_UST50_Y_RAND],rows_night_weekly[j+row].day[NEE_16_Y],rows_night_weekly[j+row].day[NEE_84_Y]);
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															rows_night_weekly[j+row].night[NEE_REF_Y],
+															rows_night_weekly[j+row].night_std[NEE_REF_Y],
+															rows_night_weekly[j+row].night_qc[NEE_REF_Y],
+															rows_night_weekly[j+row].night[NEE_REF_Y_RAND],
+															nee_ref_night_joinUnc_y,
+															rows_night_weekly[j+row].day[NEE_REF_Y],
+															rows_night_weekly[j+row].day_std[NEE_REF_Y],
+															rows_night_weekly[j+row].day_qc[NEE_REF_Y],
+															rows_night_weekly[j+row].day[NEE_REF_Y_RAND],
+															nee_ref_day_joinUnc_y,
+															rows_night_weekly[j+row].night[NEE_UST50_Y],
+															rows_night_weekly[j+row].night_std[NEE_UST50_Y],
+															rows_night_weekly[j+row].night_qc[NEE_UST50_Y],
+															rows_night_weekly[j+row].night[NEE_UST50_Y_RAND],
+															nee_ust50_night_joinUnc_y,
+															rows_night_weekly[j+row].day[NEE_UST50_Y],
+															rows_night_weekly[j+row].day_std[NEE_UST50_Y],
+															rows_night_weekly[j+row].day_qc[NEE_UST50_Y],
+															rows_night_weekly[j+row].day[NEE_UST50_Y_RAND],
+															nee_ust50_day_joinUnc_y,
+															rows_night_weekly[j+row].night[NEE_05_Y],
+															rows_night_weekly[j+row].night[NEE_05_QC_Y],
+															rows_night_weekly[j+row].night[NEE_16_Y],
+															rows_night_weekly[j+row].night[NEE_16_QC_Y],
+															rows_night_weekly[j+row].night[NEE_25_Y],
+															rows_night_weekly[j+row].night[NEE_25_QC_Y],
+															rows_night_weekly[j+row].night[NEE_50_Y],
+															rows_night_weekly[j+row].night[NEE_50_QC_Y],
+															rows_night_weekly[j+row].night[NEE_75_Y],
+															rows_night_weekly[j+row].night[NEE_75_QC_Y],
+															rows_night_weekly[j+row].night[NEE_84_Y],
+															rows_night_weekly[j+row].night[NEE_84_QC_Y],
+															rows_night_weekly[j+row].night[NEE_95_Y],
+															rows_night_weekly[j+row].night[NEE_95_QC_Y],
+															rows_night_weekly[j+row].day[NEE_05_Y],
+															rows_night_weekly[j+row].day[NEE_05_QC_Y],
+															rows_night_weekly[j+row].day[NEE_16_Y],
+															rows_night_weekly[j+row].day[NEE_16_QC_Y],
+															rows_night_weekly[j+row].day[NEE_25_Y],
+															rows_night_weekly[j+row].day[NEE_25_QC_Y],
+															rows_night_weekly[j+row].day[NEE_50_Y],
+															rows_night_weekly[j+row].day[NEE_50_QC_Y],
+															rows_night_weekly[j+row].day[NEE_75_Y],
+															rows_night_weekly[j+row].day[NEE_75_QC_Y],
+															rows_night_weekly[j+row].day[NEE_84_Y],
+															rows_night_weekly[j+row].day[NEE_84_QC_Y],
+															rows_night_weekly[j+row].day[NEE_95_Y],
+															rows_night_weekly[j+row].day[NEE_95_QC_Y]
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE
+							);
+						}
 					}
 				}
 
 				if ( datasets[dataset].years_count >= 3 ) {
 					if ( no_rand_unc ) {
 						if ( exists ) {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														rows_night_weekly[j+row].night[NEE_REF_C],
 														rows_night_weekly[j+row].night_std[NEE_REF_C],
 														rows_night_weekly[j+row].night_qc[NEE_REF_C],
@@ -7153,7 +7371,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 														rows_night_weekly[j+row].day[NEE_95_QC_C]
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
@@ -7202,7 +7421,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 							nee_ref_day_joinUnc_c = compute_join(rows_night_weekly[j+row].day[NEE_REF_C_RAND],rows_night_weekly[j+row].day[NEE_16_C],rows_night_weekly[j+row].day[NEE_84_C]);
 							nee_ust50_night_joinUnc_c = compute_join(rows_night_weekly[j+row].night[NEE_UST50_C_RAND],rows_night_weekly[j+row].night[NEE_16_C],rows_night_weekly[j+row].night[NEE_84_C]);
 							nee_ust50_day_joinUnc_c = compute_join(rows_night_weekly[j+row].day[NEE_UST50_C_RAND],rows_night_weekly[j+row].day[NEE_16_C],rows_night_weekly[j+row].day[NEE_84_C]);
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														rows_night_weekly[j+row].night[NEE_REF_C],
 														rows_night_weekly[j+row].night_std[NEE_REF_C],
 														rows_night_weekly[j+row].night_qc[NEE_REF_C],
@@ -7253,7 +7473,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 														rows_night_weekly[j+row].day[NEE_95_QC_C]
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
@@ -7349,19 +7570,23 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		printf("computing mm...");
 
 		monthly_rows_count = 12 * datasets[dataset].years_count;
-		nee_matrix_y_monthly = malloc(monthly_rows_count*sizeof*nee_matrix_y_monthly);
-		if ( !nee_matrix_y_monthly ) {
-			puts(err_out_of_memory);
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(rows_night_daily);
-			free(percentiles_y);
-			free(nee_matrix_y_daily);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c_daily);
+		if ( ! skip_y ) {
+			nee_matrix_y_monthly = malloc(monthly_rows_count*sizeof*nee_matrix_y_monthly);
+			if ( !nee_matrix_y_monthly ) {
+				puts(err_out_of_memory);
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(rows_night_daily);
+				free(percentiles_y);
+				free(nee_matrix_y_daily);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c_daily);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			nee_matrix_y_monthly = NULL;
 		}
 
 		if ( datasets[dataset].years_count >= 3 ) {
@@ -7403,8 +7628,10 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		for ( row = 0; row < rows_count; ) {
 			for ( i = 0; i < 12; i++ ) {
 				for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-					nee_matrix_y_monthly[index+i].nee[percentile] = 0.0;
-					nee_matrix_y_monthly[index+i].qc[percentile] = 0.0;
+					if ( ! skip_y ) {
+						nee_matrix_y_monthly[index+i].nee[percentile] = 0.0;
+						nee_matrix_y_monthly[index+i].qc[percentile] = 0.0;
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_monthly[index+i].nee[percentile] = 0.0;
 						nee_matrix_c_monthly[index+i].qc[percentile] = 0.0;
@@ -7414,15 +7641,19 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 						++z;
 					}
 					for ( j = 0; j < z; j++ ) {
-						nee_matrix_y_monthly[index+i].nee[percentile] += nee_matrix_y_daily[row+j].nee[percentile];
-						nee_matrix_y_monthly[index+i].qc[percentile] += nee_matrix_y_daily[row+j].qc[percentile];
+						if ( ! skip_y ) {
+							nee_matrix_y_monthly[index+i].nee[percentile] += nee_matrix_y_daily[row+j].nee[percentile];
+							nee_matrix_y_monthly[index+i].qc[percentile] += nee_matrix_y_daily[row+j].qc[percentile];
+						}
 						if ( datasets[dataset].years_count >= 3 ) {
 							nee_matrix_c_monthly[index+i].nee[percentile] += nee_matrix_c_daily[row+j].nee[percentile];
 							nee_matrix_c_monthly[index+i].qc[percentile] += nee_matrix_c_daily[row+j].qc[percentile];
 						}
 					}
-					nee_matrix_y_monthly[index+i].nee[percentile] /= z;
-					nee_matrix_y_monthly[index+i].qc[percentile] /= z;
+					if ( ! skip_y ) {
+						nee_matrix_y_monthly[index+i].nee[percentile] /= z;
+						nee_matrix_y_monthly[index+i].qc[percentile] /= z;
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_monthly[index+i].nee[percentile] /= z;
 						nee_matrix_c_monthly[index+i].qc[percentile] /= z;
@@ -7436,20 +7667,22 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* saving y nee mm matrix */
 		if ( percentiles_save ) {
-			if ( ! save_nee_matrix(nee_matrix_y_monthly, &datasets[dataset], MM_Y) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(rows_night_daily);
-				free(rows_night_monthly);
-				free(percentiles_y);
-				free(nee_matrix_y_daily);
-				free(nee_matrix_y_monthly);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c_daily);
-					free(nee_matrix_c_monthly);
+			if ( ! skip_y ) {
+				if ( ! save_nee_matrix(nee_matrix_y_monthly, &datasets[dataset], MM_Y) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(rows_night_daily);
+					free(rows_night_monthly);
+					free(percentiles_y);
+					free(nee_matrix_y_daily);
+					free(nee_matrix_y_monthly);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c_daily);
+						free(nee_matrix_c_monthly);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* saving c nee mm matrix */
@@ -7471,22 +7704,26 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 
 		/* get p_matrix */
-		p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_monthly, monthly_rows_count, &ref_y, MM_Y);
-		if ( !p_matrix_y ) {
-			puts("unable to get p_matrix for monthly y");
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(rows_night_daily);
-			free(rows_night_monthly);
-			free(percentiles_y);
-			free(nee_matrix_y_daily);
-			free(nee_matrix_y_monthly);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c_daily);
-				free(nee_matrix_c_monthly);
+		if ( ! skip_y ) {
+			p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_monthly, monthly_rows_count, &ref_y, MM_Y);
+			if ( !p_matrix_y ) {
+				puts("unable to get p_matrix for monthly y");
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(rows_night_daily);
+				free(rows_night_monthly);
+				free(percentiles_y);
+				free(nee_matrix_y_daily);
+				free(nee_matrix_y_monthly);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c_daily);
+					free(nee_matrix_c_monthly);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			p_matrix_y = NULL;
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			p_matrix_c = process_nee_matrix(&datasets[dataset], nee_matrix_c_monthly, monthly_rows_count, &ref_c, MM_C);
@@ -7513,33 +7750,41 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		/* ref changed ? */
 		if ( (ref_y_old != ref_y) || (ref_c_old != ref_c) ) {
 			/* revert back qcs */
-			revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				revert_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
 			/* compute random again */
-			if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(percentiles_y);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
-					free(nee_matrix_c_daily);
+			if ( ! no_rand_unc ) {
+				if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(percentiles_y);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* change qcs */
-			change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				change_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
-			rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres));
+			if ( ! no_rand_unc ) {
+				rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres), skip_y);
+			}
 			ref_y_old = ref_y;
 			ref_c_old = ref_c;
 		}
@@ -7562,6 +7807,16 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				rows_night_monthly[index+i].night_total /= j;
 				rows_night_monthly[index+i].day_total /= j;
 				for ( percentile = 0; percentile < NIGHT_VALUES; percentile++ ) {
+					/* do not compute _y ... */
+					if ( skip_y &&
+							((NEE_REF_Y == percentile) || (NEE_UST50_Y == percentile) || (NEE_REF_Y_RAND == percentile) || (NEE_UST50_Y_RAND == percentile) ||
+							(NEE_05_Y == percentile) || (NEE_05_QC_Y == percentile) || (NEE_16_Y == percentile) || (NEE_16_QC_Y == percentile) ||
+							(NEE_25_Y == percentile) || (NEE_25_QC_Y == percentile) || (NEE_50_Y == percentile) || (NEE_50_QC_Y == percentile) ||
+							(NEE_75_Y == percentile) || (NEE_75_QC_Y == percentile) ||
+							(NEE_84_Y == percentile) || (NEE_84_QC_Y == percentile) || (NEE_95_Y == percentile) || (NEE_95_QC_Y == percentile))
+							) {
+						continue;
+					}
 					/* do not compute _c if years count is less than 3 */
 					if ( (datasets[dataset].years_count < 3) &&
 							((NEE_REF_C == percentile) || (NEE_UST50_C == percentile) || (NEE_REF_C_RAND == percentile) || (NEE_UST50_C_RAND == percentile) ||
@@ -7684,7 +7939,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			index += i;
 		}
 
-		if ( ! update_mm(&datasets[dataset], rows_night_daily, daily_rows_count, rows_night_monthly, monthly_rows_count) ) {
+		if ( ! update_mm(&datasets[dataset], rows_night_daily, daily_rows_count, rows_night_monthly, monthly_rows_count, skip_y) ) {
 			free(unc_rows_temp);
 			free(unc_rows_aggr);
 			free(unc_rows);
@@ -7704,7 +7959,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* rand unc mm */
 		if ( ! no_rand_unc ) {
-			rand_unc_mm(unc_rows_aggr, unc_rows_temp, datasets[dataset].rows_count / rows_per_day, datasets[dataset].years[0].year, datasets[dataset].years_count);
+			rand_unc_mm(unc_rows_aggr, unc_rows_temp, datasets[dataset].rows_count / rows_per_day, datasets[dataset].years[0].year, datasets[dataset].years_count, skip_y);
 		}
 		printf("ok\nsaving mm...");
 
@@ -7732,22 +7987,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* write header mm */
 		fprintf(f, header_file_mm, TIMESTAMP_STRING);
-		if ( no_rand_unc ) {
-			fputs(output_var_1, f);
-		} else {
-			fputs(output_var_1_rand_unc, f);
-		}
-		for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
-			fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
-			if ( percentile < PERCENTILES_COUNT_1-1 ) {
-				fputs(",", f);
+		if ( ! skip_y ) {
+			if ( no_rand_unc ) {
+				fputs(output_var_1, f);
+			} else {
+				fputs(output_var_1_rand_unc, f);
+			}
+			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
+				fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
+				if ( percentile < PERCENTILES_COUNT_1-1 ) {
+					fputs(",", f);
+				}
 			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(output_var_2, f);
+				fputs(output_var_2 + skip_y, f);
 			} else {
-				fputs(output_var_2_rand_unc, f);
+				fputs(output_var_2_rand_unc + skip_y, f);
 			}
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
 				fprintf(f, "NEE_%02g_c,NEE_%02g_qc_c", percentiles_test_1[percentile],percentiles_test_1[percentile]);
@@ -7759,16 +8016,20 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		
 		if ( no_rand_unc ) {
 			fputs(header_file_night_no_rand_unc, f);
-			fputs(header_file_night_y_no_rand_unc, f);
+			if ( ! skip_y ) {
+				fputs(header_file_night_y_no_rand_unc, f);
+			}
 		} else {
 			fputs(header_file_night, f);
-			fputs(header_file_night_y, f);
+			if ( ! skip_y ) {
+				fputs(header_file_night_y, f);
+			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(header_file_night_c_no_rand_unc, f);
+				fputs(header_file_night_c_no_rand_unc + skip_y, f);
 			} else {
-				fputs(header_file_night_c, f);
+				fputs(header_file_night_c + skip_y, f);
 			}
 		} else {
 			fputs("\n", f);
@@ -7782,67 +8043,68 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				fprintf(f, "%04d%02d,",				datasets[dataset].years[i].year,
 													row+1
 				);
-
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-															nee_matrix_y_monthly[j+row].nee[ref_y],
-															nee_matrix_y_monthly[j+row].qc[ref_y],
-															nee_matrix_y_monthly[j+row].nee[PERCENTILES_COUNT_2-1],
-															nee_matrix_y_monthly[j+row].qc[PERCENTILES_COUNT_2-1],
-															p_matrix_y[j+row].mean,
-															p_matrix_y[j+row].mean_qc,
-															p_matrix_y[j+row].std_err
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																nee_matrix_y_monthly[j+row].nee[ref_y],
+																nee_matrix_y_monthly[j+row].qc[ref_y],
+																nee_matrix_y_monthly[j+row].nee[PERCENTILES_COUNT_2-1],
+																nee_matrix_y_monthly[j+row].qc[PERCENTILES_COUNT_2-1],
+																p_matrix_y[j+row].mean,
+																p_matrix_y[j+row].mean_qc,
+																p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							nee_ust50_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+																nee_matrix_y_monthly[j+row].nee[ref_y],
+																nee_matrix_y_monthly[j+row].qc[ref_y],
+																unc_rows_temp[j+row].rand[NEE_REF_Y_UNC],
+																nee_ref_joinUnc_y,
+																nee_matrix_y_monthly[j+row].nee[PERCENTILES_COUNT_2-1],
+																nee_matrix_y_monthly[j+row].qc[PERCENTILES_COUNT_2-1],
+																unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC],
+																nee_ust50_joinUnc_y,
+																p_matrix_y[j+row].mean,
+																p_matrix_y[j+row].mean_qc,
+																p_matrix_y[j+row].std_err
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE,
+																(PREC)INVALID_VALUE
+							);
+						}
 					}
-				} else {
-					if ( exists ) {
-						nee_ref_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_REF_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						nee_ust50_joinUnc_y = compute_join(unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC], p_matrix_y[j+row].value[1], p_matrix_y[j+row].value[5]);
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-															nee_matrix_y_monthly[j+row].nee[ref_y],
-															nee_matrix_y_monthly[j+row].qc[ref_y],
-															unc_rows_temp[j+row].rand[NEE_REF_Y_UNC],
-															nee_ref_joinUnc_y,
-															nee_matrix_y_monthly[j+row].nee[PERCENTILES_COUNT_2-1],
-															nee_matrix_y_monthly[j+row].qc[PERCENTILES_COUNT_2-1],
-															unc_rows_temp[j+row].rand[NEE_UST50_Y_UNC],
-															nee_ust50_joinUnc_y,
-															p_matrix_y[j+row].mean,
-															p_matrix_y[j+row].mean_qc,
-															p_matrix_y[j+row].std_err
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE,
-															(PREC)INVALID_VALUE
-						);
-					}
-				}
-				for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
-					} else {
-						fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+					for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,", p_matrix_y[j+row].value[z], p_matrix_y[j+row].qc[z]);
+						} else {
+							fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+						}
 					}
 				}
 				if ( datasets[dataset].years_count >= 3 ) {
@@ -7938,208 +8200,211 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 						);
 					}
 				}
-				if ( no_rand_unc ) {
-					if ( exists ) {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														rows_night_monthly[j+row].night[NEE_REF_Y],
-														rows_night_monthly[j+row].night_std[NEE_REF_Y],
-														rows_night_monthly[j+row].night_qc[NEE_REF_Y],
-														rows_night_monthly[j+row].day[NEE_REF_Y],
-														rows_night_monthly[j+row].day_std[NEE_REF_Y],
-														rows_night_monthly[j+row].day_qc[NEE_REF_Y],
-														rows_night_monthly[j+row].night[NEE_UST50_Y],
-														rows_night_monthly[j+row].night_std[NEE_UST50_Y],
-														rows_night_monthly[j+row].night_qc[NEE_UST50_Y],
-														rows_night_monthly[j+row].day[NEE_UST50_Y],
-														rows_night_monthly[j+row].day_std[NEE_UST50_Y],
-														rows_night_monthly[j+row].day_qc[NEE_UST50_Y],
-														rows_night_monthly[j+row].night[NEE_05_Y],
-														rows_night_monthly[j+row].night[NEE_05_QC_Y],
-														rows_night_monthly[j+row].night[NEE_16_Y],
-														rows_night_monthly[j+row].night[NEE_16_QC_Y],
-														rows_night_monthly[j+row].night[NEE_25_Y],
-														rows_night_monthly[j+row].night[NEE_25_QC_Y],
-														rows_night_monthly[j+row].night[NEE_50_Y],
-														rows_night_monthly[j+row].night[NEE_50_QC_Y],
-														rows_night_monthly[j+row].night[NEE_75_Y],
-														rows_night_monthly[j+row].night[NEE_75_QC_Y],
-														rows_night_monthly[j+row].night[NEE_84_Y],
-														rows_night_monthly[j+row].night[NEE_84_QC_Y],
-														rows_night_monthly[j+row].night[NEE_95_Y],
-														rows_night_monthly[j+row].night[NEE_95_QC_Y],
-														rows_night_monthly[j+row].day[NEE_05_Y],
-														rows_night_monthly[j+row].day[NEE_05_QC_Y],
-														rows_night_monthly[j+row].day[NEE_16_Y],
-														rows_night_monthly[j+row].day[NEE_16_QC_Y],
-														rows_night_monthly[j+row].day[NEE_25_Y],
-														rows_night_monthly[j+row].day[NEE_25_QC_Y],
-														rows_night_monthly[j+row].day[NEE_50_Y],
-														rows_night_monthly[j+row].day[NEE_50_QC_Y],
-														rows_night_monthly[j+row].day[NEE_75_Y],
-														rows_night_monthly[j+row].day[NEE_75_QC_Y],
-														rows_night_monthly[j+row].day[NEE_84_Y],
-														rows_night_monthly[j+row].day[NEE_84_QC_Y],
-														rows_night_monthly[j+row].day[NEE_95_Y],
-														rows_night_monthly[j+row].day[NEE_95_QC_Y]
-						);
+				if ( ! skip_y ) {
+					if ( no_rand_unc ) {
+						if ( exists ) {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															rows_night_monthly[j+row].night[NEE_REF_Y],
+															rows_night_monthly[j+row].night_std[NEE_REF_Y],
+															rows_night_monthly[j+row].night_qc[NEE_REF_Y],
+															rows_night_monthly[j+row].day[NEE_REF_Y],
+															rows_night_monthly[j+row].day_std[NEE_REF_Y],
+															rows_night_monthly[j+row].day_qc[NEE_REF_Y],
+															rows_night_monthly[j+row].night[NEE_UST50_Y],
+															rows_night_monthly[j+row].night_std[NEE_UST50_Y],
+															rows_night_monthly[j+row].night_qc[NEE_UST50_Y],
+															rows_night_monthly[j+row].day[NEE_UST50_Y],
+															rows_night_monthly[j+row].day_std[NEE_UST50_Y],
+															rows_night_monthly[j+row].day_qc[NEE_UST50_Y],
+															rows_night_monthly[j+row].night[NEE_05_Y],
+															rows_night_monthly[j+row].night[NEE_05_QC_Y],
+															rows_night_monthly[j+row].night[NEE_16_Y],
+															rows_night_monthly[j+row].night[NEE_16_QC_Y],
+															rows_night_monthly[j+row].night[NEE_25_Y],
+															rows_night_monthly[j+row].night[NEE_25_QC_Y],
+															rows_night_monthly[j+row].night[NEE_50_Y],
+															rows_night_monthly[j+row].night[NEE_50_QC_Y],
+															rows_night_monthly[j+row].night[NEE_75_Y],
+															rows_night_monthly[j+row].night[NEE_75_QC_Y],
+															rows_night_monthly[j+row].night[NEE_84_Y],
+															rows_night_monthly[j+row].night[NEE_84_QC_Y],
+															rows_night_monthly[j+row].night[NEE_95_Y],
+															rows_night_monthly[j+row].night[NEE_95_QC_Y],
+															rows_night_monthly[j+row].day[NEE_05_Y],
+															rows_night_monthly[j+row].day[NEE_05_QC_Y],
+															rows_night_monthly[j+row].day[NEE_16_Y],
+															rows_night_monthly[j+row].day[NEE_16_QC_Y],
+															rows_night_monthly[j+row].day[NEE_25_Y],
+															rows_night_monthly[j+row].day[NEE_25_QC_Y],
+															rows_night_monthly[j+row].day[NEE_50_Y],
+															rows_night_monthly[j+row].day[NEE_50_QC_Y],
+															rows_night_monthly[j+row].day[NEE_75_Y],
+															rows_night_monthly[j+row].day[NEE_75_QC_Y],
+															rows_night_monthly[j+row].day[NEE_84_Y],
+															rows_night_monthly[j+row].day[NEE_84_QC_Y],
+															rows_night_monthly[j+row].day[NEE_95_Y],
+															rows_night_monthly[j+row].day[NEE_95_QC_Y]
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE
+							);
+						}
 					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE
-						);
-					}
-				} else {
-					if ( exists ) {
-						nee_ref_night_joinUnc_y = compute_join(rows_night_monthly[j+row].night[NEE_REF_Y_RAND],rows_night_monthly[j+row].night[NEE_16_Y],rows_night_monthly[j+row].night[NEE_84_Y]);
-						nee_ref_day_joinUnc_y = compute_join(rows_night_monthly[j+row].day[NEE_REF_Y_RAND],rows_night_monthly[j+row].day[NEE_16_Y],rows_night_monthly[j+row].day[NEE_84_Y]);
-						nee_ust50_night_joinUnc_y = compute_join(rows_night_monthly[j+row].night[NEE_UST50_Y_RAND],rows_night_monthly[j+row].night[NEE_16_Y],rows_night_monthly[j+row].night[NEE_84_Y]);
-						nee_ust50_day_joinUnc_y = compute_join(rows_night_monthly[j+row].day[NEE_UST50_Y_RAND],rows_night_monthly[j+row].day[NEE_16_Y],rows_night_monthly[j+row].day[NEE_84_Y]);
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														rows_night_monthly[j+row].night[NEE_REF_Y],
-														rows_night_monthly[j+row].night_std[NEE_REF_Y],
-														rows_night_monthly[j+row].night_qc[NEE_REF_Y],
-														rows_night_monthly[j+row].night[NEE_REF_Y_RAND],
-														nee_ref_night_joinUnc_y,
-														rows_night_monthly[j+row].day[NEE_REF_Y],
-														rows_night_monthly[j+row].day_std[NEE_REF_Y],
-														rows_night_monthly[j+row].day_qc[NEE_REF_Y],
-														rows_night_monthly[j+row].day[NEE_REF_Y_RAND],
-														nee_ref_day_joinUnc_y,
-														rows_night_monthly[j+row].night[NEE_UST50_Y],
-														rows_night_monthly[j+row].night_std[NEE_UST50_Y],
-														rows_night_monthly[j+row].night_qc[NEE_UST50_Y],
-														rows_night_monthly[j+row].night[NEE_UST50_Y_RAND],
-														nee_ust50_night_joinUnc_y,
-														rows_night_monthly[j+row].day[NEE_UST50_Y],
-														rows_night_monthly[j+row].day_std[NEE_UST50_Y],
-														rows_night_monthly[j+row].day_qc[NEE_UST50_Y],
-														rows_night_monthly[j+row].day[NEE_UST50_Y_RAND],
-														nee_ust50_day_joinUnc_y,
-														rows_night_monthly[j+row].night[NEE_05_Y],
-														rows_night_monthly[j+row].night[NEE_05_QC_Y],
-														rows_night_monthly[j+row].night[NEE_16_Y],
-														rows_night_monthly[j+row].night[NEE_16_QC_Y],
-														rows_night_monthly[j+row].night[NEE_25_Y],
-														rows_night_monthly[j+row].night[NEE_25_QC_Y],
-														rows_night_monthly[j+row].night[NEE_50_Y],
-														rows_night_monthly[j+row].night[NEE_50_QC_Y],
-														rows_night_monthly[j+row].night[NEE_75_Y],
-														rows_night_monthly[j+row].night[NEE_75_QC_Y],
-														rows_night_monthly[j+row].night[NEE_84_Y],
-														rows_night_monthly[j+row].night[NEE_84_QC_Y],
-														rows_night_monthly[j+row].night[NEE_95_Y],
-														rows_night_monthly[j+row].night[NEE_95_QC_Y],
-														rows_night_monthly[j+row].day[NEE_05_Y],
-														rows_night_monthly[j+row].day[NEE_05_QC_Y],
-														rows_night_monthly[j+row].day[NEE_16_Y],
-														rows_night_monthly[j+row].day[NEE_16_QC_Y],
-														rows_night_monthly[j+row].day[NEE_25_Y],
-														rows_night_monthly[j+row].day[NEE_25_QC_Y],
-														rows_night_monthly[j+row].day[NEE_50_Y],
-														rows_night_monthly[j+row].day[NEE_50_QC_Y],
-														rows_night_monthly[j+row].day[NEE_75_Y],
-														rows_night_monthly[j+row].day[NEE_75_QC_Y],
-														rows_night_monthly[j+row].day[NEE_84_Y],
-														rows_night_monthly[j+row].day[NEE_84_QC_Y],
-														rows_night_monthly[j+row].day[NEE_95_Y],
-														rows_night_monthly[j+row].day[NEE_95_QC_Y]
-						);
-					} else {
-						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE,
-														(PREC)INVALID_VALUE
-						);
+						if ( exists ) {
+							nee_ref_night_joinUnc_y = compute_join(rows_night_monthly[j+row].night[NEE_REF_Y_RAND],rows_night_monthly[j+row].night[NEE_16_Y],rows_night_monthly[j+row].night[NEE_84_Y]);
+							nee_ref_day_joinUnc_y = compute_join(rows_night_monthly[j+row].day[NEE_REF_Y_RAND],rows_night_monthly[j+row].day[NEE_16_Y],rows_night_monthly[j+row].day[NEE_84_Y]);
+							nee_ust50_night_joinUnc_y = compute_join(rows_night_monthly[j+row].night[NEE_UST50_Y_RAND],rows_night_monthly[j+row].night[NEE_16_Y],rows_night_monthly[j+row].night[NEE_84_Y]);
+							nee_ust50_day_joinUnc_y = compute_join(rows_night_monthly[j+row].day[NEE_UST50_Y_RAND],rows_night_monthly[j+row].day[NEE_16_Y],rows_night_monthly[j+row].day[NEE_84_Y]);
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															rows_night_monthly[j+row].night[NEE_REF_Y],
+															rows_night_monthly[j+row].night_std[NEE_REF_Y],
+															rows_night_monthly[j+row].night_qc[NEE_REF_Y],
+															rows_night_monthly[j+row].night[NEE_REF_Y_RAND],
+															nee_ref_night_joinUnc_y,
+															rows_night_monthly[j+row].day[NEE_REF_Y],
+															rows_night_monthly[j+row].day_std[NEE_REF_Y],
+															rows_night_monthly[j+row].day_qc[NEE_REF_Y],
+															rows_night_monthly[j+row].day[NEE_REF_Y_RAND],
+															nee_ref_day_joinUnc_y,
+															rows_night_monthly[j+row].night[NEE_UST50_Y],
+															rows_night_monthly[j+row].night_std[NEE_UST50_Y],
+															rows_night_monthly[j+row].night_qc[NEE_UST50_Y],
+															rows_night_monthly[j+row].night[NEE_UST50_Y_RAND],
+															nee_ust50_night_joinUnc_y,
+															rows_night_monthly[j+row].day[NEE_UST50_Y],
+															rows_night_monthly[j+row].day_std[NEE_UST50_Y],
+															rows_night_monthly[j+row].day_qc[NEE_UST50_Y],
+															rows_night_monthly[j+row].day[NEE_UST50_Y_RAND],
+															nee_ust50_day_joinUnc_y,
+															rows_night_monthly[j+row].night[NEE_05_Y],
+															rows_night_monthly[j+row].night[NEE_05_QC_Y],
+															rows_night_monthly[j+row].night[NEE_16_Y],
+															rows_night_monthly[j+row].night[NEE_16_QC_Y],
+															rows_night_monthly[j+row].night[NEE_25_Y],
+															rows_night_monthly[j+row].night[NEE_25_QC_Y],
+															rows_night_monthly[j+row].night[NEE_50_Y],
+															rows_night_monthly[j+row].night[NEE_50_QC_Y],
+															rows_night_monthly[j+row].night[NEE_75_Y],
+															rows_night_monthly[j+row].night[NEE_75_QC_Y],
+															rows_night_monthly[j+row].night[NEE_84_Y],
+															rows_night_monthly[j+row].night[NEE_84_QC_Y],
+															rows_night_monthly[j+row].night[NEE_95_Y],
+															rows_night_monthly[j+row].night[NEE_95_QC_Y],
+															rows_night_monthly[j+row].day[NEE_05_Y],
+															rows_night_monthly[j+row].day[NEE_05_QC_Y],
+															rows_night_monthly[j+row].day[NEE_16_Y],
+															rows_night_monthly[j+row].day[NEE_16_QC_Y],
+															rows_night_monthly[j+row].day[NEE_25_Y],
+															rows_night_monthly[j+row].day[NEE_25_QC_Y],
+															rows_night_monthly[j+row].day[NEE_50_Y],
+															rows_night_monthly[j+row].day[NEE_50_QC_Y],
+															rows_night_monthly[j+row].day[NEE_75_Y],
+															rows_night_monthly[j+row].day[NEE_75_QC_Y],
+															rows_night_monthly[j+row].day[NEE_84_Y],
+															rows_night_monthly[j+row].day[NEE_84_QC_Y],
+															rows_night_monthly[j+row].day[NEE_95_Y],
+															rows_night_monthly[j+row].day[NEE_95_QC_Y]
+							);
+						} else {
+							fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE,
+															(PREC)INVALID_VALUE
+							);
+						}
 					}
 				}
 
 				if ( datasets[dataset].years_count >= 3 ) {
 					if ( no_rand_unc ) {
 						if ( exists ) {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														rows_night_monthly[j+row].night[NEE_REF_C],
 														rows_night_monthly[j+row].night_std[NEE_REF_C],
 														rows_night_monthly[j+row].night_qc[NEE_REF_C],
@@ -8182,7 +8447,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 														rows_night_monthly[j+row].day[NEE_95_QC_C]
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
@@ -8231,7 +8497,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 							nee_ref_day_joinUnc_c = compute_join(rows_night_monthly[j+row].day[NEE_REF_C_RAND],rows_night_monthly[j+row].day[NEE_16_C],rows_night_monthly[j+row].day[NEE_84_C]);
 							nee_ust50_night_joinUnc_c = compute_join(rows_night_monthly[j+row].night[NEE_UST50_C_RAND],rows_night_monthly[j+row].night[NEE_16_C],rows_night_monthly[j+row].night[NEE_84_C]);
 							nee_ust50_day_joinUnc_c = compute_join(rows_night_monthly[j+row].day[NEE_UST50_C_RAND],rows_night_monthly[j+row].day[NEE_16_C],rows_night_monthly[j+row].day[NEE_84_C]);
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														rows_night_monthly[j+row].night[NEE_REF_C],
 														rows_night_monthly[j+row].night_std[NEE_REF_C],
 														rows_night_monthly[j+row].night_qc[NEE_REF_C],
@@ -8282,7 +8549,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 														rows_night_monthly[j+row].day[NEE_95_QC_C]
 							);
 						} else {
-							fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+							fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+														skip_y ? "" : ",",
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
 														(PREC)INVALID_VALUE,
@@ -8377,20 +8645,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		printf("computing yy...");
 
-		nee_matrix_y_yearly = malloc(datasets[dataset].years_count*sizeof*nee_matrix_y_yearly);
-		if ( !nee_matrix_y_yearly ) {
-			puts(err_out_of_memory);
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(rows_night_daily);
-			free(percentiles_y);
-			free(nee_matrix_y_daily);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c_daily);
-				free(nee_matrix_c);
+		if ( ! skip_y ) {
+			nee_matrix_y_yearly = malloc(datasets[dataset].years_count*sizeof*nee_matrix_y_yearly);
+			if ( !nee_matrix_y_yearly ) {
+				puts(err_out_of_memory);
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(rows_night_daily);
+				free(percentiles_y);
+				free(nee_matrix_y_daily);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c_daily);
+					free(nee_matrix_c);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			nee_matrix_y_yearly = NULL;
 		}
 
 		if ( datasets[dataset].years_count >= 3 ) {
@@ -8433,21 +8705,27 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		for ( row = 0; row < rows_count; ) {
 			y = IS_LEAP_YEAR(year) ? 366 : 365;
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_2; percentile++ ) {
-				nee_matrix_y_yearly[index].nee[percentile] = 0.0;
-				nee_matrix_y_yearly[index].qc[percentile] = 0.0;
+				if ( ! skip_y ) {
+					nee_matrix_y_yearly[index].nee[percentile] = 0.0;
+					nee_matrix_y_yearly[index].qc[percentile] = 0.0;
+				}
 				if ( datasets[dataset].years_count >= 3 ) {
 					nee_matrix_c_yearly[index].nee[percentile] = 0.0;
 					nee_matrix_c_yearly[index].qc[percentile] = 0.0;
 				}
 				for ( j = 0; j < y; j++ ) {
-					nee_matrix_y_yearly[index].nee[percentile] += nee_matrix_y_daily[row+j].nee[percentile];
-					nee_matrix_y_yearly[index].qc[percentile] += nee_matrix_y_daily[row+j].qc[percentile];
+					if ( ! skip_y ) {
+						nee_matrix_y_yearly[index].nee[percentile] += nee_matrix_y_daily[row+j].nee[percentile];
+						nee_matrix_y_yearly[index].qc[percentile] += nee_matrix_y_daily[row+j].qc[percentile];
+					}
 					if ( datasets[dataset].years_count >= 3 ) {
 						nee_matrix_c_yearly[index].nee[percentile] += nee_matrix_c_daily[row+j].nee[percentile];
 						nee_matrix_c_yearly[index].qc[percentile] += nee_matrix_c_daily[row+j].qc[percentile];
 					}
 				}
-				nee_matrix_y_yearly[index].qc[percentile] /= y;
+				if ( ! skip_y ) {
+					nee_matrix_y_yearly[index].qc[percentile] /= y;
+				}
 				if ( datasets[dataset].years_count >= 3 ) {
 					nee_matrix_c_yearly[index].qc[percentile] /= y;
 				}
@@ -8459,21 +8737,23 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* saving y nee yy matrix */
 		if ( percentiles_save ) {
-			if ( ! save_nee_matrix(nee_matrix_y_yearly, &datasets[dataset], YY_Y) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(rows_night_yearly);
-				free(nee_matrix_y_yearly);
-				free(rows_night_daily);
-				free(percentiles_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c_yearly);
-					free(nee_matrix_c_daily);
-					free(nee_matrix_c);
+			if ( ! skip_y ) {
+				if ( ! save_nee_matrix(nee_matrix_y_yearly, &datasets[dataset], YY_Y) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(rows_night_yearly);
+					free(nee_matrix_y_yearly);
+					free(rows_night_daily);
+					free(percentiles_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c_yearly);
+						free(nee_matrix_c_daily);
+						free(nee_matrix_c);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* saving c nee yy matrix */
@@ -8496,23 +8776,27 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 
 		/* get p_matrix */
-		p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_yearly, datasets[dataset].years_count, &ref_y, YY_Y);
-		if ( !p_matrix_y ) {
-			puts("unable to get p_matrix for yearly y");
-			free(unc_rows_temp);
-			free(unc_rows_aggr);
-			free(unc_rows);
-			free(rows_night_yearly);
-			free(nee_matrix_y_yearly);
-			free(rows_night_daily);
-			free(percentiles_y);
-			free(nee_matrix_y_daily);
-			if ( datasets[dataset].years_count >= 3 ) {
-				free(nee_matrix_c_yearly);
-				free(nee_matrix_c_daily);
-				free(nee_matrix_c);
+		if ( ! skip_y ) {
+			p_matrix_y = process_nee_matrix(&datasets[dataset], nee_matrix_y_yearly, datasets[dataset].years_count, &ref_y, YY_Y);
+			if ( !p_matrix_y ) {
+				puts("unable to get p_matrix for yearly y");
+				free(unc_rows_temp);
+				free(unc_rows_aggr);
+				free(unc_rows);
+				free(rows_night_yearly);
+				free(nee_matrix_y_yearly);
+				free(rows_night_daily);
+				free(percentiles_y);
+				free(nee_matrix_y_daily);
+				if ( datasets[dataset].years_count >= 3 ) {
+					free(nee_matrix_c_yearly);
+					free(nee_matrix_c_daily);
+					free(nee_matrix_c);
+				}
+				continue;
 			}
-			continue;
+		} else {
+			p_matrix_y = NULL;
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			p_matrix_c = process_nee_matrix(&datasets[dataset], nee_matrix_c_yearly, datasets[dataset].years_count, &ref_c, YY_C);
@@ -8539,46 +8823,54 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		/* ref changed ? */
 		if ( (ref_y_old != ref_y) || (ref_c_old != ref_c) ) {
 			/* revert back qcs */
-			revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				revert_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				revert_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
 			/* compute random again */
-			if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(percentiles_y);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
-					free(nee_matrix_c_daily);
+			if ( !no_rand_unc ) {
+				if ( ! compute_rand_unc(&datasets[dataset], unc_rows, nee_matrix_y, nee_matrix_c, ref_y, ref_c) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(percentiles_y);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
 			}
 
 			/* change qcs */
-			change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			if ( ! skip_y ) {
+				change_qcs(nee_matrix_y, datasets[dataset].rows_count);
+			}
 			if ( datasets[dataset].years_count >= 3 ) {
 				change_qcs(nee_matrix_c, datasets[dataset].rows_count);
 			}
 
-			if ( ! compute_night_rand(&datasets[dataset], rows_night_daily, unc_rows) ) {
-				free(unc_rows_temp);
-				free(unc_rows_aggr);
-				free(unc_rows);
-				free(percentiles_y);
-				free(nee_matrix_y);
-				free(nee_matrix_y_daily);
-				if ( datasets[dataset].years_count >= 3 ) {
-					free(nee_matrix_c);
-					free(nee_matrix_c_daily);
+			if ( !no_rand_unc ) {
+				if ( ! compute_night_rand(&datasets[dataset], rows_night_daily, unc_rows, skip_y) ) {
+					free(unc_rows_temp);
+					free(unc_rows_aggr);
+					free(unc_rows);
+					free(percentiles_y);
+					free(nee_matrix_y);
+					free(nee_matrix_y_daily);
+					if ( datasets[dataset].years_count >= 3 ) {
+						free(nee_matrix_c);
+						free(nee_matrix_c_daily);
+					}
+					continue;
 				}
-				continue;
+				rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres), skip_y);
 			}
-			rand_unc_dd(unc_rows, unc_rows_aggr, datasets[dataset].rows_count, datasets[dataset].years_count, (HOURLY_TIMERES == datasets[dataset].details->timeres));
 			ref_y_old = ref_y;
 			ref_c_old = ref_c;
 		}
@@ -8597,6 +8889,16 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			rows_night_yearly[index].night_total /= y;
 			rows_night_yearly[index].day_total /= y;
 			for ( percentile = 0; percentile < NIGHT_VALUES; percentile++ ) {
+				/* do not compute _y if ... */
+				if ( skip_y &&
+							((NEE_REF_Y == percentile) || (NEE_UST50_Y == percentile) || (NEE_REF_Y_RAND == percentile) || (NEE_UST50_Y_RAND == percentile) ||
+							(NEE_05_Y == percentile) || (NEE_05_QC_Y == percentile) || (NEE_16_Y == percentile) || (NEE_16_QC_Y == percentile) ||
+							(NEE_25_Y == percentile) || (NEE_25_QC_Y == percentile) || (NEE_50_Y == percentile) || (NEE_50_QC_Y == percentile) ||
+							(NEE_75_Y == percentile) || (NEE_75_QC_Y == percentile) ||
+							(NEE_84_Y == percentile) || (NEE_84_QC_Y == percentile) || (NEE_95_Y == percentile) || (NEE_95_QC_Y == percentile))
+							) {
+					continue;
+				}
 				/* do not compute _c if years count is less than 3 */
 				if ( (datasets[dataset].years_count < 3) &&
 							((NEE_REF_C == percentile) || (NEE_UST50_C == percentile) || (NEE_REF_C_RAND == percentile) || (NEE_UST50_C_RAND == percentile) ||
@@ -8716,7 +9018,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			++index;
 		}
 
-		if ( ! update_yy(&datasets[dataset], rows_night_daily, daily_rows_count, rows_night_yearly, datasets[dataset].years_count) ) {
+		if ( ! update_yy(&datasets[dataset], rows_night_daily, daily_rows_count, rows_night_yearly, datasets[dataset].years_count, skip_y) ) {
 			free(unc_rows_temp);
 			free(unc_rows_aggr);
 			free(unc_rows);
@@ -8736,7 +9038,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* rand unc yy */
 		if ( !no_rand_unc ) {
-			rand_unc_yy(unc_rows_aggr, unc_rows_temp, datasets[dataset].rows_count / rows_per_day, datasets[dataset].years[0].year, datasets[dataset].years_count);
+			rand_unc_yy(unc_rows_aggr, unc_rows_temp, datasets[dataset].rows_count / rows_per_day, datasets[dataset].years[0].year, datasets[dataset].years_count, skip_y);
 		}
 		printf("ok\nsaving yy...");
 
@@ -8764,22 +9066,24 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 
 		/* write header yy */
 		fprintf(f, header_file_yy, TIMESTAMP_STRING);
-		if ( no_rand_unc ) {
-			fputs(output_var_1, f);
-		} else {
-			fputs(output_var_1_rand_unc, f);
-		}
-		for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
-			fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
-			if ( percentile < PERCENTILES_COUNT_1-1 ) {
-				fputs(",", f);
+		if ( ! skip_y ) {
+			if ( no_rand_unc ) {
+				fputs(output_var_1, f);
+			} else {
+				fputs(output_var_1_rand_unc, f);
+			}
+			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
+				fprintf(f, "NEE_%02g_y,NEE_%02g_qc_y", percentiles_test_1[percentile],percentiles_test_1[percentile]);
+				if ( percentile < PERCENTILES_COUNT_1-1 ) {
+					fputs(",", f);
+				}
 			}
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(output_var_2, f);
+				fputs(output_var_2 + skip_y, f);
 			} else {
-				fputs(output_var_2_rand_unc, f);
+				fputs(output_var_2_rand_unc + skip_y, f);
 			}
 			for ( percentile = 0; percentile < PERCENTILES_COUNT_1; percentile++ ) {
 				fprintf(f, "NEE_%02g_c,NEE_%02g_qc_c", percentiles_test_1[percentile],percentiles_test_1[percentile]);
@@ -8788,9 +9092,10 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		} else {
 			fputs(",", f);
 		}
-		if ( no_rand_unc ) {
+		
+		if ( no_rand_unc && ! skip_y ) {
 			fputs(header_file_night_y_no_rand_unc, f);
-		} else {
+		} else if ( ! skip_y ) {
 			if ( !no_rand_unc ) {
 				fputs(header_file_night_year, f);
 			}
@@ -8798,9 +9103,9 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		}
 		if ( datasets[dataset].years_count >= 3 ) {
 			if ( no_rand_unc ) {
-				fputs(header_file_night_c_no_rand_unc, f);
+				fputs(header_file_night_c_no_rand_unc + skip_y, f);
 			} else {
-				fputs(header_file_night_c, f);
+				fputs(header_file_night_c + skip_y, f);
 			}
 		} else {
 			fputs("\n", f);
@@ -8811,66 +9116,68 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 		for ( i = 0; i < datasets[dataset].years_count; i++ ) {
 			exists = datasets[dataset].years[i].exist;
 			fprintf(f, "%d,", datasets[dataset].years[i].year);
-			if ( no_rand_unc ) {
-				if ( exists ) {
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-													nee_matrix_y_yearly[i].nee[ref_y],
-													nee_matrix_y_yearly[i].qc[ref_y],
-													nee_matrix_y_yearly[i].nee[PERCENTILES_COUNT_2-1],
-													nee_matrix_y_yearly[i].qc[PERCENTILES_COUNT_2-1],
-													p_matrix_y[i].mean,
-													p_matrix_y[i].mean_qc,
-													p_matrix_y[i].std_err
-					);
+			if ( ! skip_y ) {
+				if ( no_rand_unc ) {
+					if ( exists ) {
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+														nee_matrix_y_yearly[i].nee[ref_y],
+														nee_matrix_y_yearly[i].qc[ref_y],
+														nee_matrix_y_yearly[i].nee[PERCENTILES_COUNT_2-1],
+														nee_matrix_y_yearly[i].qc[PERCENTILES_COUNT_2-1],
+														p_matrix_y[i].mean,
+														p_matrix_y[i].mean_qc,
+														p_matrix_y[i].std_err
+						);
+					} else {
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE
+						);
+					}
 				} else {
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,",
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE
-					);
+					if ( exists ) {
+						nee_ref_joinUnc_y = compute_join(unc_rows_temp[i].rand[NEE_REF_Y_UNC], p_matrix_y[i].value[1], p_matrix_y[i].value[5]);
+						nee_ust50_joinUnc_y = compute_join(unc_rows_temp[i].rand[NEE_UST50_Y_UNC], p_matrix_y[i].value[1], p_matrix_y[i].value[5]);
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+														nee_matrix_y_yearly[i].nee[ref_y],
+														nee_matrix_y_yearly[i].qc[ref_y],
+														unc_rows_temp[i].rand[NEE_REF_Y_UNC],
+														nee_ref_joinUnc_y,
+														nee_matrix_y_yearly[i].nee[PERCENTILES_COUNT_2-1],
+														nee_matrix_y_yearly[i].qc[PERCENTILES_COUNT_2-1],
+														unc_rows_temp[i].rand[NEE_UST50_Y_UNC],
+														nee_ust50_joinUnc_y,
+														p_matrix_y[i].mean,
+														p_matrix_y[i].mean_qc,
+														p_matrix_y[i].std_err
+						);
+					} else {
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE
+						);
+					}
 				}
-			} else {
-				if ( exists ) {
-					nee_ref_joinUnc_y = compute_join(unc_rows_temp[i].rand[NEE_REF_Y_UNC], p_matrix_y[i].value[1], p_matrix_y[i].value[5]);
-					nee_ust50_joinUnc_y = compute_join(unc_rows_temp[i].rand[NEE_UST50_Y_UNC], p_matrix_y[i].value[1], p_matrix_y[i].value[5]);
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-													nee_matrix_y_yearly[i].nee[ref_y],
-													nee_matrix_y_yearly[i].qc[ref_y],
-													unc_rows_temp[i].rand[NEE_REF_Y_UNC],
-													nee_ref_joinUnc_y,
-													nee_matrix_y_yearly[i].nee[PERCENTILES_COUNT_2-1],
-													nee_matrix_y_yearly[i].qc[PERCENTILES_COUNT_2-1],
-													unc_rows_temp[i].rand[NEE_UST50_Y_UNC],
-													nee_ust50_joinUnc_y,
-													p_matrix_y[i].mean,
-													p_matrix_y[i].mean_qc,
-													p_matrix_y[i].std_err
-					);
-				} else {
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,",
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE
-					);
-				}
-			}
-			for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
-				if ( exists ) {
-					fprintf(f, "%g,%g,", p_matrix_y[i].value[z], p_matrix_y[i].qc[z]);
-				} else {
-					fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+				for ( z = 0; z < PERCENTILES_COUNT_1; z++ ) {
+					if ( exists ) {
+						fprintf(f, "%g,%g,", p_matrix_y[i].value[z], p_matrix_y[i].qc[z]);
+					} else {
+						fprintf(f, "%g,%g,", (PREC)INVALID_VALUE, (PREC)INVALID_VALUE);
+					}
 				}
 			}
 			if ( datasets[dataset].years_count >= 3 ) {
@@ -8938,164 +9245,53 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				}
 			}
 
-			if ( no_rand_unc ) {
-				if ( exists ) {
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-													rows_night_yearly[i].night[NEE_REF_Y],
-													rows_night_yearly[i].night_std[NEE_REF_Y],
-													rows_night_yearly[i].night_qc[NEE_REF_Y],
-													rows_night_yearly[i].day[NEE_REF_Y],
-													rows_night_yearly[i].day_std[NEE_REF_Y],
-													rows_night_yearly[i].day_qc[NEE_REF_Y],
-													rows_night_yearly[i].night[NEE_UST50_Y],
-													rows_night_yearly[i].night_std[NEE_UST50_Y],
-													rows_night_yearly[i].night_qc[NEE_UST50_Y],
-													rows_night_yearly[i].day[NEE_UST50_Y],
-													rows_night_yearly[i].day_std[NEE_UST50_Y],
-													rows_night_yearly[i].day_qc[NEE_UST50_Y],
-													rows_night_yearly[i].night[NEE_05_Y],
-													rows_night_yearly[i].night[NEE_05_QC_Y],
-													rows_night_yearly[i].night[NEE_16_Y],
-													rows_night_yearly[i].night[NEE_16_QC_Y],
-													rows_night_yearly[i].night[NEE_25_Y],
-													rows_night_yearly[i].night[NEE_25_QC_Y],
-													rows_night_yearly[i].night[NEE_50_Y],
-													rows_night_yearly[i].night[NEE_50_QC_Y],
-													rows_night_yearly[i].night[NEE_75_Y],
-													rows_night_yearly[i].night[NEE_75_QC_Y],
-													rows_night_yearly[i].night[NEE_84_Y],
-													rows_night_yearly[i].night[NEE_84_QC_Y],
-													rows_night_yearly[i].night[NEE_95_Y],
-													rows_night_yearly[i].night[NEE_95_QC_Y],
-													rows_night_yearly[i].day[NEE_05_Y],
-													rows_night_yearly[i].day[NEE_05_QC_Y],
-													rows_night_yearly[i].day[NEE_16_Y],
-													rows_night_yearly[i].day[NEE_16_QC_Y],
-													rows_night_yearly[i].day[NEE_25_Y],
-													rows_night_yearly[i].day[NEE_25_QC_Y],
-													rows_night_yearly[i].day[NEE_50_Y],
-													rows_night_yearly[i].day[NEE_50_QC_Y],
-													rows_night_yearly[i].day[NEE_75_Y],
-													rows_night_yearly[i].day[NEE_75_QC_Y],
-													rows_night_yearly[i].day[NEE_84_Y],
-													rows_night_yearly[i].day[NEE_84_QC_Y],
-													rows_night_yearly[i].day[NEE_95_Y],
-													rows_night_yearly[i].day[NEE_95_QC_Y]
-					);
-				} else {
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE,
-												(PREC)INVALID_VALUE
-					);
-				}
-			} else {
-				if ( exists ) {
-					nee_ref_night_joinUnc_y = compute_join(rows_night_yearly[i].night[NEE_REF_Y_RAND],rows_night_yearly[i].night[NEE_16_Y],rows_night_yearly[i].night[NEE_84_Y]);
-					nee_ref_day_joinUnc_y = compute_join(rows_night_yearly[i].day[NEE_REF_Y_RAND],rows_night_yearly[i].day[NEE_16_Y],rows_night_yearly[i].day[NEE_84_Y]);
-					nee_ust50_night_joinUnc_y = compute_join(rows_night_yearly[i].night[NEE_UST50_Y_RAND],rows_night_yearly[i].night[NEE_16_Y],rows_night_yearly[i].night[NEE_84_Y]);
-					nee_ust50_day_joinUnc_y = compute_join(rows_night_yearly[i].day[NEE_UST50_Y_RAND],rows_night_yearly[i].day[NEE_16_Y],rows_night_yearly[i].day[NEE_84_Y]);
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-													rows_night_yearly[i].night_d,
-													rows_night_yearly[i].day_d,
-													rows_night_yearly[i].night[NEE_REF_Y],
-													rows_night_yearly[i].night_std[NEE_REF_Y],
-													rows_night_yearly[i].night_qc[NEE_REF_Y],
-													rows_night_yearly[i].night[NEE_REF_Y_RAND],
-													nee_ref_night_joinUnc_y,
-													rows_night_yearly[i].day[NEE_REF_Y],
-													rows_night_yearly[i].day_std[NEE_REF_Y],
-													rows_night_yearly[i].day_qc[NEE_REF_Y],
-													rows_night_yearly[i].day[NEE_REF_Y_RAND],
-													nee_ref_day_joinUnc_y,
-													rows_night_yearly[i].night[NEE_UST50_Y],
-													rows_night_yearly[i].night_std[NEE_UST50_Y],
-													rows_night_yearly[i].night_qc[NEE_UST50_Y],
-													rows_night_yearly[i].night[NEE_UST50_Y_RAND],
-													nee_ust50_night_joinUnc_y,
-													rows_night_yearly[i].day[NEE_UST50_Y],
-													rows_night_yearly[i].day_std[NEE_UST50_Y],
-													rows_night_yearly[i].day_qc[NEE_UST50_Y],
-													rows_night_yearly[i].day[NEE_UST50_Y_RAND],
-													nee_ust50_day_joinUnc_y,
-													rows_night_yearly[i].night[NEE_05_Y],
-													rows_night_yearly[i].night[NEE_05_QC_Y],
-													rows_night_yearly[i].night[NEE_16_Y],
-													rows_night_yearly[i].night[NEE_16_QC_Y],
-													rows_night_yearly[i].night[NEE_25_Y],
-													rows_night_yearly[i].night[NEE_25_QC_Y],
-													rows_night_yearly[i].night[NEE_50_Y],
-													rows_night_yearly[i].night[NEE_50_QC_Y],
-													rows_night_yearly[i].night[NEE_75_Y],
-													rows_night_yearly[i].night[NEE_75_QC_Y],
-													rows_night_yearly[i].night[NEE_84_Y],
-													rows_night_yearly[i].night[NEE_84_QC_Y],
-													rows_night_yearly[i].night[NEE_95_Y],
-													rows_night_yearly[i].night[NEE_95_QC_Y],
-													rows_night_yearly[i].day[NEE_05_Y],
-													rows_night_yearly[i].day[NEE_05_QC_Y],
-													rows_night_yearly[i].day[NEE_16_Y],
-													rows_night_yearly[i].day[NEE_16_QC_Y],
-													rows_night_yearly[i].day[NEE_25_Y],
-													rows_night_yearly[i].day[NEE_25_QC_Y],
-													rows_night_yearly[i].day[NEE_50_Y],
-													rows_night_yearly[i].day[NEE_50_QC_Y],
-													rows_night_yearly[i].day[NEE_75_Y],
-													rows_night_yearly[i].day[NEE_75_QC_Y],
-													rows_night_yearly[i].day[NEE_84_Y],
-													rows_night_yearly[i].day[NEE_84_QC_Y],
-													rows_night_yearly[i].day[NEE_95_Y],
-													rows_night_yearly[i].day[NEE_95_QC_Y]
-					);
-				} else {
-					fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
-													(PREC)INVALID_VALUE,
+			if ( ! skip_y ) {
+				if ( no_rand_unc ) {
+					if ( exists ) {
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+														rows_night_yearly[i].night[NEE_REF_Y],
+														rows_night_yearly[i].night_std[NEE_REF_Y],
+														rows_night_yearly[i].night_qc[NEE_REF_Y],
+														rows_night_yearly[i].day[NEE_REF_Y],
+														rows_night_yearly[i].day_std[NEE_REF_Y],
+														rows_night_yearly[i].day_qc[NEE_REF_Y],
+														rows_night_yearly[i].night[NEE_UST50_Y],
+														rows_night_yearly[i].night_std[NEE_UST50_Y],
+														rows_night_yearly[i].night_qc[NEE_UST50_Y],
+														rows_night_yearly[i].day[NEE_UST50_Y],
+														rows_night_yearly[i].day_std[NEE_UST50_Y],
+														rows_night_yearly[i].day_qc[NEE_UST50_Y],
+														rows_night_yearly[i].night[NEE_05_Y],
+														rows_night_yearly[i].night[NEE_05_QC_Y],
+														rows_night_yearly[i].night[NEE_16_Y],
+														rows_night_yearly[i].night[NEE_16_QC_Y],
+														rows_night_yearly[i].night[NEE_25_Y],
+														rows_night_yearly[i].night[NEE_25_QC_Y],
+														rows_night_yearly[i].night[NEE_50_Y],
+														rows_night_yearly[i].night[NEE_50_QC_Y],
+														rows_night_yearly[i].night[NEE_75_Y],
+														rows_night_yearly[i].night[NEE_75_QC_Y],
+														rows_night_yearly[i].night[NEE_84_Y],
+														rows_night_yearly[i].night[NEE_84_QC_Y],
+														rows_night_yearly[i].night[NEE_95_Y],
+														rows_night_yearly[i].night[NEE_95_QC_Y],
+														rows_night_yearly[i].day[NEE_05_Y],
+														rows_night_yearly[i].day[NEE_05_QC_Y],
+														rows_night_yearly[i].day[NEE_16_Y],
+														rows_night_yearly[i].day[NEE_16_QC_Y],
+														rows_night_yearly[i].day[NEE_25_Y],
+														rows_night_yearly[i].day[NEE_25_QC_Y],
+														rows_night_yearly[i].day[NEE_50_Y],
+														rows_night_yearly[i].day[NEE_50_QC_Y],
+														rows_night_yearly[i].day[NEE_75_Y],
+														rows_night_yearly[i].day[NEE_75_QC_Y],
+														rows_night_yearly[i].day[NEE_84_Y],
+														rows_night_yearly[i].day[NEE_84_QC_Y],
+														rows_night_yearly[i].day[NEE_95_Y],
+														rows_night_yearly[i].day[NEE_95_QC_Y]
+						);
+					} else {
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,
@@ -9136,14 +9332,128 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE
-					);
+						);
+					}
+				} else {
+					if ( exists ) {
+						nee_ref_night_joinUnc_y = compute_join(rows_night_yearly[i].night[NEE_REF_Y_RAND],rows_night_yearly[i].night[NEE_16_Y],rows_night_yearly[i].night[NEE_84_Y]);
+						nee_ref_day_joinUnc_y = compute_join(rows_night_yearly[i].day[NEE_REF_Y_RAND],rows_night_yearly[i].day[NEE_16_Y],rows_night_yearly[i].day[NEE_84_Y]);
+						nee_ust50_night_joinUnc_y = compute_join(rows_night_yearly[i].night[NEE_UST50_Y_RAND],rows_night_yearly[i].night[NEE_16_Y],rows_night_yearly[i].night[NEE_84_Y]);
+						nee_ust50_day_joinUnc_y = compute_join(rows_night_yearly[i].day[NEE_UST50_Y_RAND],rows_night_yearly[i].day[NEE_16_Y],rows_night_yearly[i].day[NEE_84_Y]);
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+														rows_night_yearly[i].night_d,
+														rows_night_yearly[i].day_d,
+														rows_night_yearly[i].night[NEE_REF_Y],
+														rows_night_yearly[i].night_std[NEE_REF_Y],
+														rows_night_yearly[i].night_qc[NEE_REF_Y],
+														rows_night_yearly[i].night[NEE_REF_Y_RAND],
+														nee_ref_night_joinUnc_y,
+														rows_night_yearly[i].day[NEE_REF_Y],
+														rows_night_yearly[i].day_std[NEE_REF_Y],
+														rows_night_yearly[i].day_qc[NEE_REF_Y],
+														rows_night_yearly[i].day[NEE_REF_Y_RAND],
+														nee_ref_day_joinUnc_y,
+														rows_night_yearly[i].night[NEE_UST50_Y],
+														rows_night_yearly[i].night_std[NEE_UST50_Y],
+														rows_night_yearly[i].night_qc[NEE_UST50_Y],
+														rows_night_yearly[i].night[NEE_UST50_Y_RAND],
+														nee_ust50_night_joinUnc_y,
+														rows_night_yearly[i].day[NEE_UST50_Y],
+														rows_night_yearly[i].day_std[NEE_UST50_Y],
+														rows_night_yearly[i].day_qc[NEE_UST50_Y],
+														rows_night_yearly[i].day[NEE_UST50_Y_RAND],
+														nee_ust50_day_joinUnc_y,
+														rows_night_yearly[i].night[NEE_05_Y],
+														rows_night_yearly[i].night[NEE_05_QC_Y],
+														rows_night_yearly[i].night[NEE_16_Y],
+														rows_night_yearly[i].night[NEE_16_QC_Y],
+														rows_night_yearly[i].night[NEE_25_Y],
+														rows_night_yearly[i].night[NEE_25_QC_Y],
+														rows_night_yearly[i].night[NEE_50_Y],
+														rows_night_yearly[i].night[NEE_50_QC_Y],
+														rows_night_yearly[i].night[NEE_75_Y],
+														rows_night_yearly[i].night[NEE_75_QC_Y],
+														rows_night_yearly[i].night[NEE_84_Y],
+														rows_night_yearly[i].night[NEE_84_QC_Y],
+														rows_night_yearly[i].night[NEE_95_Y],
+														rows_night_yearly[i].night[NEE_95_QC_Y],
+														rows_night_yearly[i].day[NEE_05_Y],
+														rows_night_yearly[i].day[NEE_05_QC_Y],
+														rows_night_yearly[i].day[NEE_16_Y],
+														rows_night_yearly[i].day[NEE_16_QC_Y],
+														rows_night_yearly[i].day[NEE_25_Y],
+														rows_night_yearly[i].day[NEE_25_QC_Y],
+														rows_night_yearly[i].day[NEE_50_Y],
+														rows_night_yearly[i].day[NEE_50_QC_Y],
+														rows_night_yearly[i].day[NEE_75_Y],
+														rows_night_yearly[i].day[NEE_75_QC_Y],
+														rows_night_yearly[i].day[NEE_84_Y],
+														rows_night_yearly[i].day[NEE_84_QC_Y],
+														rows_night_yearly[i].day[NEE_95_Y],
+														rows_night_yearly[i].day[NEE_95_QC_Y]
+						);
+					} else {
+						fprintf(f, "%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g",
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE,
+														(PREC)INVALID_VALUE
+						);
+					}
 				}
 			}
 
 			if ( datasets[dataset].years_count >= 3 ) {
 				if ( no_rand_unc ) {
 					if ( exists ) {
-						fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+						fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+													skip_y ? "" : ",",
 													rows_night_yearly[i].night[NEE_REF_C],
 													rows_night_yearly[i].night_std[NEE_REF_C],
 													rows_night_yearly[i].night_qc[NEE_REF_C],
@@ -9186,7 +9496,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													rows_night_yearly[i].day[NEE_95_QC_C]
 						);
 					} else {
-						fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+						fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+													skip_y ? "" : ",",
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,
@@ -9235,7 +9546,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 						nee_ref_day_joinUnc_c = compute_join(rows_night_yearly[i].day[NEE_REF_C_RAND],rows_night_yearly[i].day[NEE_16_C],rows_night_yearly[i].day[NEE_84_C]);
 						nee_ust50_night_joinUnc_c = compute_join(rows_night_yearly[i].night[NEE_UST50_C_RAND],rows_night_yearly[i].night[NEE_16_C],rows_night_yearly[i].night[NEE_84_C]);
 						nee_ust50_day_joinUnc_c = compute_join(rows_night_yearly[i].day[NEE_UST50_C_RAND],rows_night_yearly[i].day[NEE_16_C],rows_night_yearly[i].day[NEE_84_C]);
-						fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+						fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+													skip_y ? "" : ",",
 													rows_night_yearly[i].night[NEE_REF_C],
 													rows_night_yearly[i].night_std[NEE_REF_C],
 													rows_night_yearly[i].night_qc[NEE_REF_C],
@@ -9286,7 +9598,8 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													rows_night_yearly[i].day[NEE_95_QC_C]
 						);
 					} else {
-						fprintf(f, ",%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+						fprintf(f, "%s%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g,%g\n",
+													skip_y ? "" : ",",
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,
 													(PREC)INVALID_VALUE,


### PR DESCRIPTION
this PR fix:

- if _y computation fails but we have more than 2 year to process, _c will be computed (_y and _c are identical if we have less than 2 years to process)

- if u* thresold files aren't found or all invalid, no computation is done