### PR TITLE
qc_auto now supports multiple EC measurement heights used to calculat…

### DIFF
--- a/oneflux_steps/qc_auto/src/dataset.c
+++ b/oneflux_steps/qc_auto/src/dataset.c
@@ -241,10 +241,14 @@ static int set_height(DATASET *const dataset) {
 	/* TODO - check for date range */
 	/* finally after many years! 20250805 */
 	if (  1 == dataset->details->htower_count ) {
-		for ( i = 0; i < dataset->rows_count; i++ ) {
-			dataset->rows[i].value[HEIGHT] = dataset->details->htower[0].h;
+		if ( dataset->details->htower[0].timestamp.YYYY != dataset->details->year ) {
+			puts("The YYYY component of the htower timestamp must match the value specified in the year field");
+		} else {
+			for ( i = 0; i < dataset->rows_count; i++ ) {
+				dataset->rows[i].value[HEIGHT] = dataset->details->htower[0].h;
+			}
+			ret = 1;
 		}
-		ret = 1;
 	} else {
 		if ( (dataset->details->timeres != HALFHOURLY_TIMERES) && (dataset->details->timeres != HOURLY_TIMERES) ) {
 			puts("To correctly set the height, timeres must be half-hourly or hourly");
@@ -259,15 +263,18 @@ static int set_height(DATASET *const dataset) {
 
 			/* compute ranges */
 			/* check for first timestamp that MUST BE YYYY01010030 for hh or YYYY01010100 for h */
-			if (	(dataset->details->htower[0].timestamp.MM != 1)
+			if (	(dataset->details->htower[0].timestamp.YYYY != dataset->details->year)
+					|| (dataset->details->htower[0].timestamp.MM != 1)
 					|| (dataset->details->htower[0].timestamp.DD != 1)
 					|| (dataset->details->htower[0].timestamp.hh != hh)
 					|| (dataset->details->htower[0].timestamp.mm != mm) ) {
+				printf("the first timestamp for height must be in the format ");
 				if ( HOURLY_TIMERES == dataset->details->timeres ) {
-					puts("the first timestamp for height must be in the format YYYY01010100");
+					printf("YYYY01010100");
 				} else {
-					puts("the first timestamp for height must be in the format YYYY01010030");
+					printf("YYYY01010030");
 				}
+				puts(", where YYYY must match the year specified in the year field");
 			} else {
 				int *row_index = malloc(dataset->details->htower_count*sizeof*row_index);
 				if ( !row_index ) {


### PR DESCRIPTION
…e storage with the discrete approach.

Previously, only the first height specified in the file's "htower" field
was used to calculate the storage with the discrete approach.
qc_auto now supports multiple EC measurement heights, which may result
from changes in the setup, for example, to track canopy height growth,
even within the same year (e.g. in the case of crops).
The calculation of FCSTORTT, which may be used to derive NEE in case a
proper storage measurement is missing, now is based on all heights
specified in the file's "htower" field and the respective dates.

The following checks are added:

- The time resolution must be either half-hourly or hourly.
- The first timestamp must be YYYY01010030 for half-hourly data and
YYYY01010100 for hourly data.
- The timestamps must fall within the year of the file.
- The timestamps must be in progressive order.