### PR TITLE
adding gf indexes for gf_mds and nee_proc

### DIFF
--- a/oneflux_steps/common/common.c
+++ b/oneflux_steps/common/common.c
@@ -57,6 +57,8 @@ static const char dd_field_delimiter[] = ",\r\n";
 static const char *dds[DETAILS_SIZE] = { "site", "year", "lat", "lon", "timezone", "htower", "timeres", "sc_negl", "notes" };
 static const char *timeress[TIMERES_SIZE] = { "spot", "quaterhourly", "halfhourly", "hourly", "daily", "monthly" };
 static const char variadic[] = "variadic";
+/* for gf_mds v3.0.1 */
+static const char indices_header[] = "ZERO_BASED_INDEX,SAMPLES_COUNT,ZERO_BASED_INDICES\n";
 
 /* error strings */
 static const char err_unable_open_path[] = "unable to open path: %s\n\n";
@@ -68,6 +70,8 @@ static const char err_unknown_argument[] = "unknown argument: \"%s\"\n\n";
 static const char err_too_long_arg[] = "too long argument\n";
 static const char err_gf_too_less_values[] = "too few valid values to apply gapfilling\n";
 static const char err_wildcards_with_no_extension_used[] = "wildcards with no extension used\n";
+/* for gf_mds v3.0.1 */
+static const char err_unable_create_indices_file[] = "unable to create indices file!\n";
 
 /* external strings */
 const char err_out_of_memory[] = "out of memory";
@@ -332,7 +336,8 @@ FILES *get_files(const char *const program_path, char *string, int *const count,
 		/* no grouping */
 		if ( !plusses_count ) {
 			/* token is a path ? */
-			if ( token_by_comma[token_length-1] == FOLDER_DELIMITER ) {
+			/* we handle both backslashes \ and forward slashes / */
+			if ( (token_by_comma[token_length-1] == '\\') || (token_by_comma[token_length-1] == '/') ) {
 			#if defined (_WIN32)
 				/* add length of filter */
 				for ( i = 0; filter[i]; i++ );
@@ -408,10 +413,10 @@ FILES *get_files(const char *const program_path, char *string, int *const count,
 					/* copy token */
 					strcpy(p2, program_path);
 
-					#if defined (_WIN32)
-						/* add filter at end */
-						strcat(p2, token_by_comma);
-					#endif
+				#if defined (_WIN32)
+					/* add filter at end */
+					strcat(p2, token_by_comma);
+				#endif
 
 					/* scan path */
 					if ( !scan_path(p2) ) {
@@ -2363,7 +2368,7 @@ PREC gf_get_similiar_median(const GF_ROW *const gf_rows, const int rows_count, i
 	return result;
 }
 
-/* static function for gapfilling. This is the core gapfillign function called only internally */
+/* static function for gapfilling. This is the core gapfilling function called only internally */
 static int gapfill(	PREC *values,
 					const int struct_size,
 					GF_ROW *const gf_rows,
@@ -2386,6 +2391,10 @@ static int gapfill(	PREC *values,
 					const int value2_column,
 					const int value3_column,
 					const int sym_mean,
+
+					/* for gf_mds v3.0.1 */
+					FILE* indices_file,
+
 					const int debug,
 					const char* debug_file_name,
 					int debug_start_year) {
@@ -2631,6 +2640,17 @@ static int gapfill(	PREC *values,
 		}
 
 		if ( samples_count > 1 ) {
+			
+			/* for gf_mds v3.01 */
+			if ( indices_file ) {
+				int k;
+				fprintf(indices_file, "%d,%d", current_row, samples_count);
+				for ( k = 0; k < samples_count; ++k ) {
+					fprintf(indices_file, ",%d", gf_rows[k].index);
+				}
+				fputs("\n", indices_file);
+			}
+			
 			/* set mean */
 			gf_rows[current_row].filled = gf_get_similiar_mean(gf_rows, samples_count);
 
@@ -2731,16 +2751,28 @@ GF_ROW *gf_mds(	PREC *values,
 				int *no_gaps_filled_count,
 				int sym_mean,
 				int max_mdv_win,
+				
+				/* for gf_mds v3.0.1 */
+				const char* indices_file_name,
+
 				int debug,
 				const char* debug_file_name,
 				int debug_start_year) {
 	int i;
 	int c;
 	int valids_count;
+
+	/* for gf_mds v3.0.1 */
+	FILE* indices_file;
+	FILE* indices_file_tmp;
+
 	GF_ROW *gf_rows;
 
 	/* */
 	assert(values && rows_count && no_gaps_filled_count);
+	
+	/* for gf_mds v3.0.1 */
+	indices_file = NULL; /* required */
 
 	/* reset */
 	*no_gaps_filled_count = 0;
@@ -2752,11 +2784,26 @@ GF_ROW *gf_mds(	PREC *values,
 	} else if ( end_row > rows_count ) {
 		end_row = rows_count;
 	}
+	
+	/* for gf_mds v3.01 */
+	if ( indices_file_name ) {
+		indices_file = fopen(indices_file_name, "w");
+		if ( !indices_file ) {
+			puts(err_unable_create_indices_file);
+			return NULL;
+		} else {
+			fputs(indices_header, indices_file);
+		}
+	}
 
 	/* allocate memory */
 	gf_rows = malloc(rows_count*sizeof*gf_rows);
 	if ( !gf_rows ) {
 		puts(err_out_of_memory);
+		
+		/* for gf_mds v3.01 */
+		fclose(indices_file);
+
 		return NULL;
 	}
 
@@ -2835,6 +2882,10 @@ GF_ROW *gf_mds(	PREC *values,
 
 	if ( valids_count < values_min ) {
 		puts(err_gf_too_less_values);
+		
+		/* for gf_mds v3.01 */
+		fclose(indices_file);
+		
 		free(gf_rows);
 		return NULL;
 	}
@@ -2871,17 +2922,23 @@ GF_ROW *gf_mds(	PREC *values,
 			continue;
 		}
 
+		/* for gf_mds v3.0.1 */
+		/* for HAT we do not need indices! */
+		indices_file_tmp = indices_file;
+		if ( !IS_INVALID_VALUE(gf_rows[i].filled) )
+			indices_file_tmp = NULL;
+
 		/*	fill gaps. If a values is impossible to fill it remains -9999 with QC also -9999 */
-		if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 7, 14, 7, GF_ALL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, debug, debug_file_name, debug_start_year) ) {
-			if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 7, 7, 7, GF_VALUE1_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, debug, debug_file_name, debug_start_year) ) {
-				if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 0, 2, 1, GF_TOFILL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, debug, debug_file_name, debug_start_year) ) {
-					if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 21, 77, 7, GF_ALL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, debug, debug_file_name, debug_start_year) ) {
-						if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 14, 77, 7, GF_VALUE1_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, debug, debug_file_name, debug_start_year) ) {
+		if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 7, 14, 7, GF_ALL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, indices_file_tmp, debug, debug_file_name, debug_start_year) ) {
+			if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 7, 7, 7, GF_VALUE1_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, indices_file_tmp, debug, debug_file_name, debug_start_year) ) {
+				if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 0, 2, 1, GF_TOFILL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, indices_file_tmp, debug, debug_file_name, debug_start_year) ) {
+					if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 21, 77, 7, GF_ALL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, indices_file_tmp, debug, debug_file_name, debug_start_year) ) {
+						if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 14, 77, 7, GF_VALUE1_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, indices_file_tmp, debug, debug_file_name, debug_start_year) ) {
 							int max_win = end_row + 1;
 							if ( (max_mdv_win > 0) && ((max_mdv_win * 2) + 1 < end_row + 1) ) {
 								max_win = (max_mdv_win * 2) + 1;
 							}
-							if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 3, max_win, 3, GF_TOFILL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, debug, debug_file_name, debug_start_year) ) {
+							if ( !gapfill(values, struct_size, gf_rows, start_row, end_row, i, 3, max_win, 3, GF_TOFILL_METHOD, timeres, value1_tolerance_min, value1_tolerance_max, value2_tolerance_min, value2_tolerance_max, value3_tolerance_min, value3_tolerance_max, tofill_column, value1_column, value2_column, value3_column, sym_mean, indices_file_tmp, debug, debug_file_name, debug_start_year) ) {
 								++*no_gaps_filled_count;
 								continue;
 							}
@@ -2895,6 +2952,11 @@ GF_ROW *gf_mds(	PREC *values,
 		gf_rows[i].quality =	(gf_rows[i].method > 0) +
 								((gf_rows[i].method == 1 && gf_rows[i].time_window > 14) || (gf_rows[i].method == 2 && gf_rows[i].time_window > 14) || (gf_rows[i].method == 3 && gf_rows[i].time_window > 1)) +
 								((gf_rows[i].method == 1 && gf_rows[i].time_window > 56) || (gf_rows[i].method == 2 && gf_rows[i].time_window > 28) || (gf_rows[i].method == 3 && gf_rows[i].time_window > 5));
+	}
+
+	/* for gf_mds v3.0.1 */
+	if ( indices_file ) {
+		fclose(indices_file);
 	}
 
 	/* ok */

--- a/oneflux_steps/common/common.c
+++ b/oneflux_steps/common/common.c
@@ -2015,7 +2015,7 @@ int check_timestamp(const TIMESTAMP* const p)
 	if ( (p->MM <= 0) || (p->MM > 12) ) return 0;
 	if ( p->DD <= 0 ) return 0;
 
-	if ( 2 == p->MM ) // check for february leap
+	if ( 2 == p->MM ) /* check for february leap */
 	{
 		if ( p->DD > days_per_month[p->MM-1]
 				+ IS_LEAP_YEAR(p->YYYY) )
@@ -2028,7 +2028,7 @@ int check_timestamp(const TIMESTAMP* const p)
 		return 0;
 	}
 
-	// fix 24 hh
+	/* fix 24 hh */
 	hour = p->hh;
 	if ( (hour < 0) || (hour > 23) ) return 0;
 	if ( (p->mm < 0) || (p->hh > 59) ) return 0;
@@ -2119,8 +2119,8 @@ TIMESTAMP *timestamp_get_by_row(int row, int yy, const int timeres, const int st
 
 	/* get hour */
 	if ( QUATERHOURLY_TIMERES == timeres ) {
-		// TODO
-		// CHECK THIS!
+		/* TODO */
+		/* CHECK THIS! */
 		t.hh = (row % rows_per_day) / 4;
 		t.mm = (row % 15) * 15;
 	} else if ( HALFHOURLY_TIMERES == timeres ) {
@@ -2641,7 +2641,7 @@ static int gapfill(	PREC *values,
 
 		if ( samples_count > 1 ) {
 			
-			/* for gf_mds v3.01 */
+			/* for gf_mds v3.0.1 */
 			if ( indices_file ) {
 				int k;
 				fprintf(indices_file, "%d,%d", current_row, samples_count);
@@ -2785,7 +2785,7 @@ GF_ROW *gf_mds(	PREC *values,
 		end_row = rows_count;
 	}
 	
-	/* for gf_mds v3.01 */
+	/* for gf_mds v3.0.1 */
 	if ( indices_file_name ) {
 		indices_file = fopen(indices_file_name, "w");
 		if ( !indices_file ) {
@@ -2801,7 +2801,7 @@ GF_ROW *gf_mds(	PREC *values,
 	if ( !gf_rows ) {
 		puts(err_out_of_memory);
 		
-		/* for gf_mds v3.01 */
+		/* for gf_mds v3.0.1 */
 		fclose(indices_file);
 
 		return NULL;
@@ -2883,7 +2883,7 @@ GF_ROW *gf_mds(	PREC *values,
 	if ( valids_count < values_min ) {
 		puts(err_gf_too_less_values);
 		
-		/* for gf_mds v3.01 */
+		/* for gf_mds v3.0.1 */
 		fclose(indices_file);
 		
 		free(gf_rows);
@@ -4334,14 +4334,14 @@ PREC *get_rpot(DD *const details) {
 
 void check_memory_leak(void) {
 #ifdef _DEBUG
-#if _WIN32
+#ifdef _WIN32
 	_CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_DEBUG);
 	_CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
 	_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
 	_CrtDumpMemoryLeaks();
-//#else /* _WIN32 */
-	//	no memory leak checker available for this platform!
-#endif
+#else
+	assert(0 && "no memory leak checker available for this platform!");
+#endif /* _WIN32 */
 #endif /* _DEBUG */
 }
 

--- a/oneflux_steps/common/common.h
+++ b/oneflux_steps/common/common.h
@@ -381,6 +381,10 @@ GF_ROW *gf_mds(PREC *values,
 	int *no_gaps_filled_count,
 	int sym_mean,
 	int max_mdv_win,
+	
+	/* for gf_mds v3.0.1 */
+	const char* indices_file_name,
+
 	int debug,
 	const char* debug_file_name,
 	int debug_start_year

--- a/oneflux_steps/energy_proc/src/dataset.c
+++ b/oneflux_steps/energy_proc/src/dataset.c
@@ -1860,6 +1860,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													&no_gaps_filled_count,
 													0,
 													0,
+													NULL,
 													0,
 													NULL,
 													0);
@@ -1930,6 +1931,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													&no_gaps_filled_count,
 													0,
 													0,
+													NULL,
 													0,
 													NULL,
 													0);
@@ -2000,6 +2002,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 																&no_gaps_filled_count,
 																0,
 																45,
+																NULL,
 																0,
 																NULL,
 																0);		

--- a/oneflux_steps/meteo_proc/src/dataset.c
+++ b/oneflux_steps/meteo_proc/src/dataset.c
@@ -1332,27 +1332,19 @@ static int import_meteo_values(DATASET *const dataset, MDS_VARS* mds_vars) {
 				}
 				/* check for user mds vars */
 				if ( mds_vars ) {
-					///* check if token is defs */
-					//for ( y = 0; y < DEF_VARS_COUNT; ++y ) {
-					//	if ( !string_compare_i(token, sz_defs[y]) ) {
-					//		break;
-					//	}
-					//}
-					//if ( DEF_VARS_COUNT == i ) {
-						for ( y = 0; y < mds_vars->count; ++y ) {
-							int z;
+					for ( y = 0; y < mds_vars->count; ++y ) {
+						int z;
 
-							/* we loop for each vars name of mds vars */
-							/* we skip MDS_VAR_TO_FILL, it is mandatory! */
-							for ( z = MDS_VAR_DRIVER_1; z < MDS_VARS_COUNT; ++z ) {
-								if ( mds_vars->vars[y].columns[z] >= USER_DRIVERS_BEGIN ) {
-									if ( !string_compare_i(token, mds_vars->vars[y].name[z]) ) {
-										columns_index[MET_VALUES + (z-1) + (y*3)] = i;
-									}
+						/* we loop for each vars name of mds vars */
+						/* we skip MDS_VAR_TO_FILL, it is mandatory! */
+						for ( z = MDS_VAR_DRIVER_1; z < MDS_VARS_COUNT; ++z ) {
+							if ( mds_vars->vars[y].columns[z] >= USER_DRIVERS_BEGIN ) {
+								if ( !string_compare_i(token, mds_vars->vars[y].name[z]) ) {
+									columns_index[MET_VALUES + (z-1) + (y*3)] = i;
 								}
 							}
 						}
-					//}
+					}
 				}
 
 				/* check for TS */
@@ -1588,7 +1580,7 @@ static int import_meteo_values(DATASET *const dataset, MDS_VARS* mds_vars) {
 												value = INVALID_VALUE;
 											}
 										}
-									#endif // 0
+									#endif
 									} else {
 										if ( !IS_INVALID_VALUE(value) && !IS_INVALID_VALUE(mds_vars->vars[index / 3].oors[index % 3][MDS_VAR_OOR_MIN]) ) {
 											if (	(value < mds_vars->vars[index / 3].oors[index % 3][MDS_VAR_OOR_MIN])
@@ -4324,8 +4316,6 @@ int check_met_files(DATASET *const dataset) {
 
 /* */
 int compute_datasets(DATASET *const datasets, const int datasets_count, MDS_VARS* mds_vars) {
-	//USER_DRIVER* uds = NULL;	/* mandatory */
-	//int uds_count = 0;		/* mandatory */
 	int ret = 0; /* defaults to err */
 	int i;
 	int j;
@@ -4578,6 +4568,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count, MDS_VARS
 										&not_gf_count,
 										0,
 										0,
+										NULL,
 										0,
 										NULL,
 										0
@@ -4685,6 +4676,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count, MDS_VARS
 									&not_gf_count,
 									0,
 									0,
+									NULL,
 									0,
 									NULL,
 									0
@@ -4788,6 +4780,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count, MDS_VARS
 									&not_gf_count,
 									0,
 									0,
+									NULL,
 									0,
 									NULL,
 									0

--- a/oneflux_steps/nee_proc/src/dataset.c
+++ b/oneflux_steps/nee_proc/src/dataset.c
@@ -707,26 +707,6 @@ static int create_nee_matrix_for_ref(NEE_MATRIX *const nee_matrix
 									, int timeres
 									, const char* site)
 {
-	/* debug stuff - adding artificial missing data for test
-	{
-		int i;
-
-		for ( i = 0; i < 850; ++i )
-		{
-			nee_matrix[i].nee[39] = INVALID_VALUE;
-			nee_matrix[i].qc[39] = mef_qc + 1;
-			nee_matrix[i].qc_ori[39] = mef_qc + 1;
-		}
-
-		for ( i = rows_count - 2000; i < rows_count; ++i )
-		{
-			nee_matrix[i].nee[39] = INVALID_VALUE;
-			nee_matrix[i].qc[39] = mef_qc + 1;
-			nee_matrix[i].qc_ori[39] = mef_qc + 1;
-		}
-	}
-	*/
-
 	*nee_matrix_ref = malloc(rows_count*sizeof**nee_matrix_ref);
 	if ( ! *nee_matrix_ref ) {
 		puts(err_out_of_memory);
@@ -1523,6 +1503,73 @@ void free_datasets(DATASET *datasets, const int datasets_count) {
 		clear_dataset(&datasets[i]);
 	}
 	free(datasets);
+}
+
+/* v1.0.3 */
+int check_ustar_mp(DATASET* dataset)
+{
+	char buffer[BUFFER_SIZE]; /* should be enough */
+	int ret;
+	int i;
+	int year;
+	int error;
+	FILE* f;
+
+	ret = 0;
+	for ( year = 0; year < dataset->years_count; ++year ) {
+		sprintf(buffer, "%s%s_usmp_%d.txt", ustar_mp_files_path, dataset->details->site, dataset->years[year].year);
+
+		/* open file */
+		f = fopen(buffer, "r");
+		if ( f ) {
+			/*
+				PLEASE NOTE:
+				FOLLOWING CODE SKIP "USTAR_MP_SKIP" ROWS AND THEN CHECK FOR " forward mode 2" string!
+				MORE FAST BUT LESS ROBUST THAN THE DISABLED ONES!
+				ENABLED FOR CONSISTENCY!
+				Alessio - June 27, 2022
+			*/
+			for ( i = 0; i < USTAR_MP_SKIP; i++ ) {
+				if ( !fgets(buffer, BUFFER_SIZE, f) ) {
+					break;
+				}
+			}
+
+			if ( i == USTAR_MP_SKIP ) {
+				for ( i = 0; buffer[i]; i++ ) {
+					if ( ('\r' == buffer[i]) || ('\n' == buffer[i]) ) {
+						buffer[i] = '\0';
+						break;
+					}
+				}
+
+				if ( !string_compare_i(buffer, " forward mode 2") ) {
+					for ( i = 0; i < BOOTSTRAPPING_TIMES; i++ ) {
+						/* BUFFER_SIZE is big so no buffer overflow should occurs */
+						if ( EOF == fscanf(f, "%s", buffer) ){
+							break ;
+						} else {
+							convert_string_to_prec(buffer, &error);
+							if ( error )
+								break;
+						}
+					}
+
+					if ( i == BOOTSTRAPPING_TIMES ) {
+						ret = 1;
+					}
+				}
+			}
+
+			fclose(f);
+
+			if ( ret )
+				break;
+		}	
+	}
+
+	/* */
+	return ret;
 }
 
 /* */
@@ -3845,6 +3892,13 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 												((datasets[dataset].years_count > 1) ? "s" : "")
 		);
 
+		/* v1.0.3 */
+		if ( ! check_ustar_mp(&datasets[dataset]) ) {
+			puts("no ustar_mp files found!");
+			free(percentiles_y);
+			continue;
+		}
+
 		/* allocate memory */
 		nee_matrix_y = malloc(datasets[dataset].rows_count*sizeof*nee_matrix_y);
 		if ( !nee_matrix_y ) {
@@ -4411,6 +4465,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			continue;
 		}
 
+		/* debug purposes */
 		/*
 		{
 			FILE *f = fopen("dataset_dump.csv", "w");
@@ -4441,6 +4496,7 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			}
 		}
 
+		/* debug purposes */
 		/*
 		{
 			FILE *f = fopen("dataset_dump_w_meteo.csv", "w");
@@ -4527,8 +4583,11 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 					printf("%g NEE values removed.\n", (PREC)element/rows_count);
 				} else {
 					printf("%d -> filtering is not possible\n", datasets[dataset].years[year].year);
-					on_error = 1;
-					skip_y = 1;
+					/* v1.0.3 */
+					if ( datasets[dataset].years[year].exist ) {
+						on_error = 1;
+						skip_y = 1;
+					}
 					break;
 				}
 

--- a/oneflux_steps/nee_proc/src/dataset.c
+++ b/oneflux_steps/nee_proc/src/dataset.c
@@ -10,6 +10,11 @@
 */
 
 /* includes */
+#ifdef _WIN32
+#define STRICT
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -52,6 +57,9 @@ extern int qc_gf_threshold;
 extern int mef_qc;
 extern int mef_min_gap;
 extern int mef_max_gap;
+
+/* v1.0.3 */
+extern int indices_save;
 
 /* constants */
 #define QC_AUTO_FILENAME_LEN		23		/* including extension */
@@ -238,6 +246,26 @@ static const char model_efficiency_c_not[] = "NEE_ref_c = not filtered!\n";
 static const char model_efficiency_y_not[] = "NEE_ref_y not filtered!\n";
 
 static const char *time_resolution[TRS] = { "hh", "dd", "ww", "mm", "yy" };
+
+/* v1.0.3 */
+int rename_file(const char* src, const char* dst)
+{
+#ifdef _WIN32
+	return MoveFile(src, dst) ? 1 : 0;
+#else
+	return (-1 == rename(src, dst)) ? 0 : 1;
+#endif
+}
+
+/* v1.0.3 */
+int remove_file(const char* filename)
+{
+#ifdef _WIN32
+	return DeleteFile(filename) ? 1 : 0;	
+#else
+	return (0 == remove(filename));
+#endif
+}
 
 /* todo : implement a better comparison for equality */
 static int compare_value_qc(const void * a, const void * b) {
@@ -4473,10 +4501,12 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 								datasets[dataset].rows[index+row].value[NEE_VALUE] = INVALID_VALUE;
 								++element;
 							}
-							/* flag for the USTAR filtering (also in the else if below): flag=0  for data not filtered,
-							flag=1 for the first value of a period removed due to low USTAR, flag=2 for hh removed due to
-							low USTAR but with also the previous hh removed, flag=3 for hh of high ustar removed because at
-							the end of the low USTAR period*/
+							/*
+								flag for the USTAR filtering (also in the else if below): flag=0  for data not filtered,
+								flag=1 for the first value of a period removed due to low USTAR, flag=2 for hh removed due to
+								low USTAR but with also the previous hh removed, flag=3 for hh of high ustar removed because at
+								the end of the low USTAR period
+							*/
 							if ( compute_nee_flags ) {
 								nee_flags_y[index+row].value[percentile] = 1;	
 								if ( row && ((nee_flags_y[index+row-1].value[percentile] >= 1) && (nee_flags_y[index+row-1].value[percentile] < 3)) ) {
@@ -4510,6 +4540,11 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				break;
 			}
 
+			/* v1.0.3 */
+			/* creating filename for saving indices */
+			if ( indices_save )
+				sprintf(buffer, "%s%s_indices_percentiles_%g_y.csv", output_files_path, datasets[dataset].details->site, percentiles_test_2[percentile]);
+
 			/* gapfilling */
 			printf("     -> gf...");
 			datasets[dataset].gf_rows = gf_mds(	datasets[dataset].rows->value,
@@ -4540,6 +4575,10 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 												&no_gaps_filled_count,
 												0,
 												0,
+
+												/* v1.0.3 */
+												indices_save ? buffer : NULL,
+
 												0,
 												NULL,
 												0);
@@ -4768,6 +4807,11 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				}
 				printf("%g NEE values removed.", (PREC)element / datasets[dataset].rows_count);
 
+				/* v1.0.3 */
+				/* creating filename for saving indices */
+				if ( indices_save )
+					sprintf(buffer, "%s%s_indices_percentiles_%g_c.csv", output_files_path, datasets[dataset].details->site, percentiles_test_2[percentile]);
+
 				/* gapfilling */
 				printf(" gf...");
 				free(datasets[dataset].gf_rows);
@@ -4799,6 +4843,10 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 													&no_gaps_filled_count,
 													0,
 													0,
+
+													/* v1.0.3 */
+													indices_save ? buffer : NULL,
+
 													0,
 													NULL,
 													0);
@@ -4977,6 +5025,27 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 			p_matrix_y = NULL;
 		}
 
+		/* v1.0.3 */
+		if ( indices_save ) {
+			if ( ! skip_y ) {
+				for ( i = 0; i < PERCENTILES_COUNT_2; ++i ) {
+					sprintf(buffer, "%s%s_indices_percentiles_%g_y.csv", output_files_path, datasets[dataset].details->site, percentiles_test_2[i]);
+					if ( i == ref_y ) {
+						/* rename */
+						sprintf(buffer2, "%s%s_indices_percentiles_ref_y.csv", output_files_path, datasets[dataset].details->site, percentiles_test_2[i]);
+						if ( ! rename_file(buffer, buffer2) ) {
+							printf("unable to rename %s in %s!\n", buffer, buffer2);
+						}
+					} else {
+						/* remove */
+						if ( ! remove_file(buffer) ) {
+							printf("unable to remove %s!\n", buffer);
+						}
+					}
+				}
+			}			
+		}
+
 		/* process nee_matrix c */
 		ref_c = -1;
 		ref_c_old = -1;
@@ -4999,6 +5068,25 @@ int compute_datasets(DATASET *const datasets, const int datasets_count) {
 				free(nee_matrix_y);
 				free(nee_matrix_c);
 				continue;
+			}
+		}
+
+		/* v1.0.3 */
+		if ( indices_save ) {
+			for ( i = 0; i < PERCENTILES_COUNT_2; ++i ) {
+				sprintf(buffer, "%s%s_indices_percentiles_%g_c.csv", output_files_path, datasets[dataset].details->site, percentiles_test_2[i]);
+				if ( i == ref_c ) {
+					/* rename */
+					sprintf(buffer2, "%s%s_indices_percentiles_ref_c.csv", output_files_path, datasets[dataset].details->site, percentiles_test_2[i]);
+					if ( ! rename_file(buffer, buffer2) ) {
+						printf("unable to rename %s in %s!\n", buffer, buffer2);
+					}
+				} else {
+					/* remove */
+					if ( ! remove_file(buffer) ) {
+						printf("unable to remove %s!\n", buffer);
+					}
+				}
 			}
 		}
 

--- a/oneflux_steps/nee_proc/src/main.c
+++ b/oneflux_steps/nee_proc/src/main.c
@@ -24,7 +24,7 @@
 #include "../../compiler.h"
 
 /* constants */
-#define PROGRAM_VERSION			"v1.021"
+#define PROGRAM_VERSION			"v1.0.3"
 #define BUFFER_SIZE				1024
 #define QC_AUTO_PATH			"qc_auto"
 #define USTAR_MP_PATH			"ustar_mp"
@@ -44,6 +44,10 @@ int compute_nee_flags = 0;					/* default if off */
 int use_met_gf = 0;							/* default is off */
 int mef_save = 0;							/* default is off */
 int percentiles_save = 0;					/* default is off */
+
+/* v1.0.3 */
+int indices_save = 0;						/* default is off */
+
 int qc_gf_threshold = QC_GF_THRESHOLD;		/* see types.h */
 int mef_qc = 2;
 int mef_min_gap = 5 * 48;
@@ -88,6 +92,10 @@ static char msg_usage[] =	"How to use: nee_proc parameter\n\n"
 							"             that can be created (i.e. if shorted than mef_min_gap the data will not be removed)\n"
 							"             ( default is %d )\n\n"
 							"    -percentiles -> save percentiles for DD,WW,MM,YY time resolution\n\n"
+
+							/* v1.0.3 */
+							"    -indices -> save the index of each sample used in the gf for ref y and ref c\n\n"
+
 							"    -h -> show this help\n\n";
 
 /* */
@@ -227,6 +235,10 @@ int main(int argc, char *argv[]) {
 		{ "mef_min_gap", set_int_value, &mef_min_gap },
 		{ "mef_max_gap", set_int_value, &mef_max_gap },
 		{ "percentiles", set_flag, &percentiles_save },
+
+		/* v1.0.3 */
+		{ "indices", set_flag, &indices_save },
+
 		{ "qc_gf_thrs", set_int_value, &qc_gf_threshold },
 		{ "h", show_help, NULL },
 		{ "help", show_help, NULL },
@@ -352,6 +364,10 @@ int main(int argc, char *argv[]) {
 	if ( 3 == mef_qc ) {
 		puts("warning: mef not filtered.\n");
 	}
+
+	/* v1.0.3 */
+	if ( indices_save )
+		printf("saving ref gf sample indices enabled!\n\n");
 
 	/* show qc gf threshold */
 	if ( use_met_gf ) {

--- a/oneflux_steps/tools/gf_mds/src/main.c
+++ b/oneflux_steps/tools/gf_mds/src/main.c
@@ -21,7 +21,7 @@
 #include "../../../compiler.h"
 	
 /* constants */
-#define PROGRAM_VERSION "3.0"
+#define PROGRAM_VERSION "3.0.1"
 const char def_tokens[GF_TOKENS][GF_TOKEN_LENGTH_MAX+1] =
 {
 	"NEE"
@@ -45,6 +45,9 @@ static int driver2b_qc_col = -1;
 static PREC driver1_qc_thrs = INVALID_VALUE;
 static PREC driver2a_qc_thrs = INVALID_VALUE;
 static PREC driver2b_qc_thrs = INVALID_VALUE;
+
+/* v3.0.1 */
+static int save_indices = 0;
 
 /* global variables */
 char *program_path = NULL;										/* required */
@@ -81,6 +84,9 @@ static const char gap_format[] = "%s,%g,%g,%d,%g,%d,%g,%d,%d,%d\n";
 /* v2.04b */
 static const char gap_header_sym_mean[] = "%s,%s,FILLED,QC,HAT,DT,DT_MA,DT_MA_SAMPLE,DT_MB,DT_MB_SAMPLE,SAMPLE,STDDEV,METHOD,QC_HAT,TIMEWINDOW\n";
 static const char gap_format_sym_mean[] = "%s,%g,%g,%d,%g,%g,%g,%d,%g,%d,%d,%g,%d,%d,%d\n";
+
+/* v3.0.1 */
+static const char gap_indices_file[] = "%s%smds_indices.csv";
 
 /* messages */
 static const char msg_dataset_not_specified[] =
@@ -153,6 +159,10 @@ static const char msg_usage[] =	"This code applies the gapfilling Marginal Distr
 								"    even if not missing, enabled by default)\n\n"
 								"  -sym_mean -> enable symmetric mean method\n\n"
 								"  -max_mdv_win=value -> set max window to be used when MDV is applied as last option\n\n"
+								
+								/* v3.0.1 */
+								"  -indices -> save the index of each sample used in the gf analysis\n\n"
+
 								"  -debug -> save used values to compute gf to file\n\n"
 								"  -h -> show this help\n\n"
 ;
@@ -186,9 +196,6 @@ static void clean_up(void) {
 	if ( program_path ) {
 		free(program_path);
 	}
-#if defined (_WIN32) && defined (_DEBUG) 
-	dump_memory_leaks();
-#endif
 }
 
 /* */
@@ -515,6 +522,9 @@ int main(int argc, char *argv[]) {
 		{ "driver1_qc_thrs", set_prec_value, &driver1_qc_thrs },
 		{ "driver2a_qc_thrs", set_prec_value, &driver2a_qc_thrs },
 		{ "driver2b_qc_thrs", set_prec_value, &driver2b_qc_thrs },
+		
+		/* v3.0.1 */
+		{ "indices", reverse_flag, &save_indices },
 
 		{ "h", show_help, NULL },
 		{ "?", show_help, NULL },
@@ -563,7 +573,10 @@ int main(int argc, char *argv[]) {
 	/* output path specified ? */
 	if ( output_path ) {
 		/* check if last char is a FOLDER_DELIMITER */
-		if ( output_path[strlen(output_path)-1] != FOLDER_DELIMITER ) {
+		
+		/* v3.0.1 */
+		/* we handle both backslashes \ and forward slashes / */
+		if ( (output_path[strlen(output_path)-1] != '\\') && (output_path[strlen(output_path)-1] != '/' ) ) {
 			printf(err_output_path_no_delimiter, FOLDER_DELIMITER);
 			return 1;
 		}
@@ -691,6 +704,11 @@ int main(int argc, char *argv[]) {
 			}
 			sprintf(debug_name, "%.*s", len, files[z].list->name);
 		}
+		
+		/* v3.0.1 */
+		if ( save_indices ) {
+			sprintf(buffer, gap_indices_file, output_path, filename);
+		}
 
 		/* gf */
 		gf_rows = gf_mds(	rows->value,
@@ -721,6 +739,10 @@ int main(int argc, char *argv[]) {
 							&no_gaps_filled_count,
 							sym_mean,
 							max_mdv_win,
+							
+							/* v3.0.1 */
+							save_indices ? buffer : NULL,
+
 							debug,
 							debug_name,
 							years[z]


### PR DESCRIPTION
### Updates

- **gf_mds** upgraded to version `v3.0.1`  
  - Introduced a new parameter `-indices`, which stores the index of each sample used in the gap-filling analysis.  
  - The output file is named: `INPUT_FILENAME_mds_indices.csv`.

- To reflect the updated function signature of the shared gap-filling function, **energy_proc** and **meteo_proc** have also been updated.  
  - These tools do **not** introduce any new parameters.  
  - Indices are **not** saved in their outputs.

- **nee_proc** upgraded to version `v1.0.3`  
  - Added a new parameter `-indices`, which saves the index of each sample used in the gap-filling analysis for reference percentile.  
  - Output files are named:  
    - `SITE_indices_percentiles_ref_y.csv`  
    - `SITE_indices_percentiles_ref_c.csv`